### PR TITLE
_reader not set in FilePrinter

### DIFF
--- a/ESCPOS_NET/Printers/FilePrinter.cs
+++ b/ESCPOS_NET/Printers/FilePrinter.cs
@@ -11,8 +11,9 @@ namespace ESCPOS_NET
         public FilePrinter(string filePath) : base()
         {
             _path = filePath;
-            _file = File.OpenWrite(filePath);
+            _file = File.Open(filePath, FileMode.Open);
             _writer = new BinaryWriter(_file);
+            _reader = new BinaryReader(_file);
         }
 
         ~FilePrinter()


### PR DESCRIPTION
The field _reader of BasePrinter is not set when using a FilePrinter. Because of that, the Read method of the BasePrinter throws a NullReferenceException and the printer status is not read.