### PR TITLE
Moved clean up code out of disposing condition

### DIFF
--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -247,21 +247,22 @@ namespace ESCPOS_NET
                 return;
             }
 
+
+            _cancellationTokenSource?.Cancel();
+            FlushTimer?.Stop();
+            if (FlushTimer != null)
+            {
+                FlushTimer.Elapsed -= Flush;
+            }
+
+            FlushTimer?.Dispose();
+            Reader?.Close();
+            Reader?.Dispose();
+            Writer?.Close();
+            Writer?.Dispose();
+
             if (disposing)
             {
-                _cancellationTokenSource?.Cancel();
-                FlushTimer?.Stop();
-                if (FlushTimer != null)
-                {
-                    FlushTimer.Elapsed -= Flush;
-                }
-               
-                FlushTimer?.Dispose();
-                Reader?.Close();
-                Reader?.Dispose();
-                Writer?.Close();
-                Writer?.Dispose();
-                
                 OverridableDispose();
             }
             disposed = true;


### PR DESCRIPTION
This does not need to be inside the disposing condition. We also want to make sure we don't leave the timer event hanging around, as it may cause a memory leak.