### PR TITLE
Fix White Background on Images

### DIFF
--- a/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
+++ b/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
@@ -19,6 +19,7 @@ namespace SixLabors.ImageSharp
                     });
                 }
 
+                img.BackgroundColor(Color.White);
                 img.Grayscale().BinaryDither(KnownDitherings.Stucki);
 
                 if (!rasterFormat)


### PR DESCRIPTION
### Description
Currently the `Transparent` color of image is printed in `Black`.

This fix the Background color of image to `White` and print `Transparent` color to `White`.
