### PR TITLE
Fix processing null-value after timeout

### DIFF
--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -195,8 +195,8 @@ namespace ESCPOS_NET
                     };
 
                     StatusChanged?.Invoke(this, Status);
-                    return;
                 }
+                return;
             }
 #if DEBUG
             var bytesToString = string.Empty;


### PR DESCRIPTION
move the return statement a level higher to prevent exception due to processing the null-array after a timeout is hit,