### PR TITLE
Changed QRCode max data validation based on QRCode type specs

### DIFF
--- a/ESCPOS_NET/DataValidation/DataValidator.cs
+++ b/ESCPOS_NET/DataValidation/DataValidator.cs
@@ -174,9 +174,9 @@ namespace ESCPOS_NET.DataValidation
                 _constraints = new Dictionary<TwoDimensionCodeType, DataConstraint>()
                 {
                     { TwoDimensionCodeType.PDF417, new DataConstraint() { MinLength = 0, MaxLength = 255 } },
-                    { TwoDimensionCodeType.QRCODE_MODEL1, new DataConstraint() { MinLength = 0, MaxLength = 254 } },
-                    { TwoDimensionCodeType.QRCODE_MODEL2, new DataConstraint() { MinLength = 0, MaxLength = 254 } },
-                    { TwoDimensionCodeType.QRCODE_MICRO, new DataConstraint() { MinLength = 0, MaxLength = 254 } },
+                    { TwoDimensionCodeType.QRCODE_MODEL1, new DataConstraint() { MinLength = 0, MaxLength = 707 } },
+                    { TwoDimensionCodeType.QRCODE_MODEL2, new DataConstraint() { MinLength = 0, MaxLength = 4296 } },
+                    { TwoDimensionCodeType.QRCODE_MICRO, new DataConstraint() { MinLength = 0, MaxLength = 21 } },
                 };
             }
 


### PR DESCRIPTION
This might solve #71 

Since I didn't have a printer to actually test it, I researched QRCode specs and found [this](https://www.keyence.com/ss/products/auto_id/barcode_lecture/basic_2d/qr/)

I used the max data alphanumeric chars that each type of QRCode can contain.

Also: Model1 is actually a prototype and has more than 14 variants, so I guess some scanners are unable to read it? I guess one should always try to use Model2