### PR TITLE
Added alias method to help with QRCode printing

### DIFF
--- a/ESCPOS_NET.ConsoleTest/Test2DCodes.cs
+++ b/ESCPOS_NET.ConsoleTest/Test2DCodes.cs
@@ -25,7 +25,7 @@ namespace ESCPOS_NET.ConsoleTest
             e.PrintLine(),
 
             e.PrintLine("QRCODE MODEL 2:"),
-            e.Print2DCode(TwoDimensionCodeType.QRCODE_MODEL2, websiteString),
+            e.Print(websiteString),
             e.PrintLine(),
 
             e.PrintLine("QRCODE MICRO:"),

--- a/ESCPOS_NET.ConsoleTest/Test2DCodes.cs
+++ b/ESCPOS_NET.ConsoleTest/Test2DCodes.cs
@@ -25,7 +25,7 @@ namespace ESCPOS_NET.ConsoleTest
             e.PrintLine(),
 
             e.PrintLine("QRCODE MODEL 2:"),
-            e.Print(websiteString),
+            e.PrintQRCode(websiteString),
             e.PrintLine(),
 
             e.PrintLine("QRCODE MICRO:"),

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/BarcodeCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/BarcodeCommands.cs
@@ -39,6 +39,16 @@ namespace ESCPOS_NET.Emitters
             return command.ToArray();
         }
 
+        public byte[] PrintQRCode(string data, TwoDimensionCodeType type = TwoDimensionCodeType.QRCODE_MODEL2, Size2DCode size = Size2DCode.NORMAL, CorrectionLevel2DCode correction = CorrectionLevel2DCode.PERCENT_7)
+        {
+            if (type == TwoDimensionCodeType.PDF417)
+            {
+                throw new ArgumentException($"{nameof(TwoDimensionCodeType.PDF417)} is not a valid QRCode type. Please use {nameof(Print2DCode)} method", nameof(type));
+            }
+
+            return Print2DCode(type, data, size, correction);
+        }
+
         public byte[] Print2DCode(TwoDimensionCodeType type, string data, Size2DCode size = Size2DCode.NORMAL, CorrectionLevel2DCode correction = CorrectionLevel2DCode.PERCENT_7)
         {
             DataValidator.Validate2DCode(type, data);

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -73,6 +73,8 @@
         /* Barcode Commands */
         byte[] PrintBarcode(BarcodeType type, string barcode, BarcodeCode code = BarcodeCode.CODE_B);
 
+        byte[] PrintQRCode(string data, TwoDimensionCodeType type = TwoDimensionCodeType.QRCODE_MODEL2, Size2DCode size = Size2DCode.NORMAL, CorrectionLevel2DCode correction = CorrectionLevel2DCode.PERCENT_7);
+
         byte[] Print2DCode(TwoDimensionCodeType type, string data, Size2DCode size = Size2DCode.NORMAL, CorrectionLevel2DCode correction = CorrectionLevel2DCode.PERCENT_7);
 
         byte[] SetBarcodeHeightInDots(int height);


### PR DESCRIPTION
This can make it easy for first-comers that want to use the library for QRCode printing. Realized that during an issue discussion.

I also realized that the project doesn't have any unit tests. Maybe it would be another good thing to help with automated regression tests. @lukevp what do you think about it?

For example, I could do an Assert on this new method for whenever a type different from QRCodes is informed, the method throws the ArgumentException. This way, in the future, if for any reason this stops to happen we can easily see when and fix it.