### PR TITLE
Fix hardcoded baudRate in ConsoleTest

### DIFF
--- a/ESCPOS_NET.ConsoleTest/Program.cs
+++ b/ESCPOS_NET.ConsoleTest/Program.cs
@@ -50,7 +50,7 @@ namespace ESCPOS_NET.ConsoleTest
                     {
                         baudRate = "115200";
                     }
-                    printer = new SerialPrinter(portName: comPort, baudRate: 115200);
+                    printer = new SerialPrinter(portName: comPort, baudRate: int.Parse(baudRate));
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {


### PR DESCRIPTION
Fix for COM port baudRate in ConsoleTest project so it can be set at values other than 115200.