### PR TITLE
Feature/migrate to simpletcp lib

### DIFF
--- a/ESCPOS_NET.ConsoleTest/ESCPOS_NET.ConsoleTest.csproj
+++ b/ESCPOS_NET.ConsoleTest/ESCPOS_NET.ConsoleTest.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 

--- a/ESCPOS_NET.ConsoleTest/Program.cs
+++ b/ESCPOS_NET.ConsoleTest/Program.cs
@@ -84,7 +84,6 @@ namespace ESCPOS_NET.ConsoleTest
                 ip = Console.ReadLine();
                 if (string.IsNullOrWhiteSpace(ip))
                 {
-                    ip = "192.168.1.240";
                     ip = "192.168.254.202";
                 }
                 Console.Write("TCP Port (enter for default 9100): ");

--- a/ESCPOS_NET.ConsoleTest/Program.cs
+++ b/ESCPOS_NET.ConsoleTest/Program.cs
@@ -246,7 +246,8 @@ namespace ESCPOS_NET.ConsoleTest
         private static void StatusChanged(object sender, EventArgs ps)
         {
             var status = (PrinterStatusEventArgs)ps;
-            Console.WriteLine($"Printer Online Status: {status.IsCoverOpen}");
+            if (status == null) { Console.WriteLine("Status was null - unable to read status from printer."); return; }
+            Console.WriteLine($"Printer Online Status: {status.DeviceIsConnected}");
             Console.WriteLine(JsonConvert.SerializeObject(status));
         }
         private static bool _hasEnabledStatusMonitoring = false;

--- a/ESCPOS_NET.ConsoleTest/TestPrinting.cs
+++ b/ESCPOS_NET.ConsoleTest/TestPrinting.cs
@@ -5,7 +5,7 @@ namespace ESCPOS_NET.ConsoleTest
 {
     public static partial class Tests
     {
-        public static byte[][] Printing(ICommandEmitter e) => new byte[][] {
+        public static byte[][] MultiLinePrinting(ICommandEmitter e) => new byte[][] {
             e.Print("Multiline Test: Windows...\r\nOSX...\rUnix...\n"),
             //TODO: sanitize test.
             e.PrintLine("Feeding 250 dots."),
@@ -16,6 +16,10 @@ namespace ESCPOS_NET.ConsoleTest
             e.PrintLine("Reverse Feeding 6 lines."),
             e.FeedLinesReverse(6),
             e.PrintLine("Done Reverse Feeding.")
+        };
+
+        public static byte[][] SingleLinePrinting(ICommandEmitter e) => new byte[][] {
+            e.Print("Single Test Line Of Text\r\n"),
         };
     }
 }

--- a/ESCPOS_NET.TCPPrintServerTest/ESCPOS_NET.TCPPrintServerTest.csproj
+++ b/ESCPOS_NET.TCPPrintServerTest/ESCPOS_NET.TCPPrintServerTest.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/ESCPOS_NET.TCPPrintServerTest/Program.cs
+++ b/ESCPOS_NET.TCPPrintServerTest/Program.cs
@@ -1,0 +1,40 @@
+﻿// This code is adapted from a sample found at the URL 
+// "http://blogs.msdn.com/b/jmanning/archive/2004/12/19/325699.aspx"
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.IO;
+using System.Text;
+
+namespace TcpEchoServer
+{
+	public class TcpEchoServer
+	{
+		public static void Main()
+		{
+			Console.WriteLine("Starting echo server...");
+
+			int port = 9100;
+			TcpListener listener = new TcpListener(IPAddress.Loopback, port);
+			listener.Start();
+
+			TcpClient client = listener.AcceptTcpClient();
+			NetworkStream stream = client.GetStream();
+			StreamWriter writer = new StreamWriter(stream, Encoding.ASCII) { AutoFlush = true };
+			StreamReader reader = new StreamReader(stream, Encoding.ASCII);
+
+			while (true)
+			{
+				string inputLine = "";
+				while (inputLine != null)
+				{
+					inputLine = reader.ReadLine();
+					writer.Write("E");
+					Console.WriteLine("Echoing string: " + inputLine);
+				}
+				Console.WriteLine("Server saw disconnect from client.");
+			}
+		}
+	}
+}

--- a/ESCPOS_NET.sln
+++ b/ESCPOS_NET.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31512.422
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ESCPOS_NET", "ESCPOS_NET\ESCPOS_NET.csproj", "{BA181101-43A5-435E-8744-ACDA313D04D8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ESCPOS_NET.ConsoleTest", "ESCPOS_NET.ConsoleTest\ESCPOS_NET.ConsoleTest.csproj", "{958464FE-6B30-4BA7-A4B1-D63ED2E23158}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ESCPOS_NET.UnitTest", "ESCPOS_NET.UnitTest\ESCPOS_NET.UnitTest.csproj", "{8A848879-9776-4EBC-8484-41B8EE65FD8D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ESCPOS_NET.UnitTest", "ESCPOS_NET.UnitTest\ESCPOS_NET.UnitTest.csproj", "{8A848879-9776-4EBC-8484-41B8EE65FD8D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ESCPOS_NET.TCPPrintServerTest", "ESCPOS_NET.TCPPrintServerTest\ESCPOS_NET.TCPPrintServerTest.csproj", "{A79EB8C9-618F-40AD-ADF3-8794F07E240D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{8A848879-9776-4EBC-8484-41B8EE65FD8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A848879-9776-4EBC-8484-41B8EE65FD8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8A848879-9776-4EBC-8484-41B8EE65FD8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A79EB8C9-618F-40AD-ADF3-8794F07E240D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A79EB8C9-618F-40AD-ADF3-8794F07E240D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A79EB8C9-618F-40AD-ADF3-8794F07E240D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A79EB8C9-618F-40AD-ADF3-8794F07E240D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -30,6 +30,7 @@ Allows creating receipts with all common functionality supported.</Description>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
     <PackageReference Include="System.IO.Ports" Version="4.6.0" />
   </ItemGroup>
 

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -23,6 +23,8 @@ Allows creating receipts with all common functionality supported.</Description>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -26,12 +26,9 @@ Allows creating receipts with all common functionality supported.</Description>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
     <PackageReference Include="System.IO.Ports" Version="4.6.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
 </Project>

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/StatusCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/StatusCommands.cs
@@ -8,5 +8,11 @@ namespace ESCPOS_NET.Emitters
         public virtual byte[] EnableAutomaticStatusBack() => new byte[] { Cmd.GS, Status.AutomaticStatusBack, 0xFF };
 
         public virtual byte[] EnableAutomaticInkStatusBack() => new byte[] { Cmd.GS, Status.AutomaticInkStatusBack, 0xFF };
+        public virtual byte[] DisableAutomaticStatusBack() => new byte[] { Cmd.GS, Status.AutomaticStatusBack, 0x00 };
+
+        public virtual byte[] DisableAutomaticInkStatusBack() => new byte[] { Cmd.GS, Status.AutomaticInkStatusBack, 0x00 };
+        public virtual byte[] RequestPaperStatus() => new byte[] { Cmd.GS, Status.RequestStatus,  0x31 };
+        public virtual byte[] RequestDrawerStatus() => new byte[] { Cmd.GS, Status.RequestStatus, 0x32 };
+        public virtual byte[] RequestInkStatus() => new byte[] { Cmd.GS, Status.RequestStatus, 0x34 };
     }
 }

--- a/ESCPOS_NET/Emitters/BaseCommandValues/Status.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandValues/Status.cs
@@ -4,5 +4,6 @@
     {
         public static readonly byte AutomaticStatusBack = 0x61;
         public static readonly byte AutomaticInkStatusBack = 0x6A;
+        public static readonly byte RequestStatus = 0x72;
     }
 }

--- a/ESCPOS_NET/Extensions/TaskExtensions.cs
+++ b/ESCPOS_NET/Extensions/TaskExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ESCPOS_NET.Extensions
+{
+    public static class TaskExtensions
+    {
+        public static void LogExceptions(this Task task)
+        {
+            task.ContinueWith(t =>
+            {
+                var aggException = t.Exception.Flatten();
+                foreach (var exception in aggException.InnerExceptions)
+                {
+                    Logging.Logger?.LogError(exception, "Uncaught Thread Exception.");
+                }
+            },
+            TaskContinuationOptions.OnlyOnFaulted);
+        }
+    }
+}

--- a/ESCPOS_NET/Logging/BaseLogger.cs
+++ b/ESCPOS_NET/Logging/BaseLogger.cs
@@ -1,9 +1,19 @@
 ﻿using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 
 namespace ESCPOS_NET
 {
     public static class Logging
     {
         public static ILogger Logger { get; set; }
+        static Logging()
+        {
+
+            TaskScheduler.UnobservedTaskException += (s, e) =>
+                {
+                    //LogUnhandledException(e.Exception, "TaskScheduler.UnobservedTaskException");
+                    e.SetObserved();
+                };
+        }
     }
 }

--- a/ESCPOS_NET/Logging/BaseLogger.cs
+++ b/ESCPOS_NET/Logging/BaseLogger.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ESCPOS_NET
+{
+    public static class Logging
+    {
+        public static ILogger Logger { get; set; }
+    }
+}

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -289,7 +289,15 @@ namespace ESCPOS_NET
 
                     //Logging.Logger?.LogDebug($"[{PrinterName}] MonitorConnectivity polling printer for status.");
                     // Enqueue a status request.
-                    WriteBuffer.Enqueue(new byte[] { Cmd.GS, ESCPOS_NET.Emitters.BaseCommandValues.Status.RequestStatus, 0x31 });
+
+
+
+                    //WriteBuffer.Enqueue(new byte[] { Cmd.GS, ESCPOS_NET.Emitters.BaseCommandValues.Status.RequestStatus, 0x31 });
+
+
+
+
+
                     // TODO: write status request
                     // TODO: track last read/write time.  If no read or write has happened in a while, fire idle event
                     // TODO: if no read has happened in x amount of time, fire disconnected event and try to reconnect.

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -87,6 +87,13 @@ namespace ESCPOS_NET
                     Logging.Logger?.LogDebug("[{PrinterName}]:[{Function}] Write Long-Running Task Cancellation was requested.", PrinterName, nameof(WriteLongRunningTask));
                     break;
                 }
+
+                await Task.Delay(100);
+                if (!IsConnected)
+                {
+                    continue;
+                }
+
                 try
                 {
                     var didDequeue = WriteBuffer.TryDequeue(out var nextBytes);
@@ -99,14 +106,13 @@ namespace ESCPOS_NET
                 {
                     // Thrown if the printer times out the socket connection
                     // default is 90 seconds
-                    Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing IOException... sometimes happens with network printers. Should get reconnected automatically.");
+                    //Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing IOException... sometimes happens with network printers. Should get reconnected automatically.");
                 }
                 catch (Exception ex)
                 {
                     // Swallow the exception
-                    Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.");
+                    //Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.");
                 }
-                await Task.Delay(50);
             }
         }
 
@@ -120,7 +126,10 @@ namespace ESCPOS_NET
                     break;
                 }
 
+                await Task.Delay(100);
+
                 if (Reader == null) continue;
+                if (!IsConnected) continue;
 
                 try
                 {
@@ -160,7 +169,6 @@ namespace ESCPOS_NET
                     // Swallow the exception
                     Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.");
                 }
-                await Task.Delay(50);
             }
         }
 
@@ -279,7 +287,7 @@ namespace ESCPOS_NET
                 else if (connectedStatus == true)
                 {
 
-                    Logging.Logger?.LogDebug($"[{PrinterName}] MonitorConnectivity polling printer for status.");
+                    //Logging.Logger?.LogDebug($"[{PrinterName}] MonitorConnectivity polling printer for status.");
                     // Enqueue a status request.
                     WriteBuffer.Enqueue(new byte[] { Cmd.GS, ESCPOS_NET.Emitters.BaseCommandValues.Status.RequestStatus, 0x31 });
                     // TODO: write status request
@@ -319,12 +327,12 @@ namespace ESCPOS_NET
                 {
                     try
                     {
-                        Logging.Logger?.LogInformation($"[{PrinterName}] MonitorConnectivity: Reconnecting...");
+                        //Logging.Logger?.LogInformation($"[{PrinterName}] MonitorConnectivity: Reconnecting...");
                         Reconnect();
                     }
                     catch (Exception e)
                     {
-                        Logging.Logger?.LogError(e, $"[{PrinterName}] MonitorConnectivity: Unable to reconnect. Trying again...");
+                        //Logging.Logger?.LogError(e, $"[{PrinterName}] MonitorConnectivity: Unable to reconnect. Trying again...");
                         lastConnectionStatus = null;
                     }
                     await Task.Delay(3000);

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -71,7 +71,7 @@ namespace ESCPOS_NET
                 var acquiredMutex = InstanceReadLockMutex.WaitOne(5000);
                 if (!acquiredMutex)
                 {
-                    Logging.Logger.LogError($"[{PrinterName}] Read was unable to acquire mutex...");
+                    Logging.Logger?.LogError($"[{PrinterName}] Read was unable to acquire mutex...");
                     continue;
                 }
 
@@ -98,21 +98,21 @@ namespace ESCPOS_NET
                     }
                     catch
                     {
-                        Logging.Logger.LogDebug($"[{PrinterName}] Swallowing OperationCanceledException... secondary issue during dispose of cancellation token.");
+                        Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing OperationCanceledException... secondary issue during dispose of cancellation token.");
                     }
-                    Logging.Logger.LogDebug($"[{PrinterName}] Swallowing OperationCanceledException... this is used to turn off status monitoring.");
+                    Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing OperationCanceledException... this is used to turn off status monitoring.");
 
                 }
                 catch (IOException ex)
                 {
                     // Thrown if the printer times out the socket connection
                     // default is 90 seconds
-                    Logging.Logger.LogDebug($"[{PrinterName}] Swallowing IOException... sometimes happens with network printers. Should get reconnected automatically.");
+                    Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing IOException... sometimes happens with network printers. Should get reconnected automatically.");
                 }
                 catch (Exception ex)
                 {
                     // Swallow the exception
-                    Logging.Logger.LogDebug($"[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.");
+                    Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.");
                 }
                 InstanceReadLockMutex.ReleaseMutex();
             }
@@ -127,13 +127,13 @@ namespace ESCPOS_NET
         {
             if (!IsConnected)
             {
-                Logging.Logger.LogInformation($"[{PrinterName}] Attempted to write but printer isn't connected. Attempting to reconnect...");
+                Logging.Logger?.LogInformation($"[{PrinterName}] Attempted to write but printer isn't connected. Attempting to reconnect...");
                 Reconnect();
             }
 
             if (!IsConnected)
             {
-                Logging.Logger.LogError($"[{PrinterName}] Unrecoverable connectivity error writing to printer.");
+                Logging.Logger?.LogError($"[{PrinterName}] Unrecoverable connectivity error writing to printer.");
                 throw new IOException("Unrecoverable connectivity error writing to printer.");
             }
 
@@ -145,7 +145,7 @@ namespace ESCPOS_NET
                 var acquiredMutex = InstanceWriteLockMutex.WaitOne(5000);
                 if (!acquiredMutex)
                 {
-                    Logging.Logger.LogError($"[{PrinterName}] Write was unable to acquire mutex...");
+                    Logging.Logger?.LogError($"[{PrinterName}] Write was unable to acquire mutex...");
                     continue;
                 }
 
@@ -159,7 +159,7 @@ namespace ESCPOS_NET
                     Reconnect();
                     if (!IsConnected)
                     {
-                        Logging.Logger.LogError(e, $"[{PrinterName}] Unrecoverable connectivity error writing to printer.");
+                        Logging.Logger?.LogError(e, $"[{PrinterName}] Unrecoverable connectivity error writing to printer.");
                         throw new IOException("Unrecoverable connectivity error writing to printer.");
                     }
                     Writer.Write(bytes, bytePointer, count);
@@ -193,7 +193,7 @@ namespace ESCPOS_NET
             }
             catch (Exception ex)
             {
-                Logging.Logger.LogError(ex, $"[{PrinterName}] Flush threw exception.");
+                Logging.Logger?.LogError(ex, $"[{PrinterName}] Flush threw exception.");
             }
         }
 
@@ -202,7 +202,7 @@ namespace ESCPOS_NET
             if (!_isMonitoring)
             {
                 _isMonitoring = true;
-                Logging.Logger.LogDebug($"[{PrinterName}] Started Monitoring.");
+                Logging.Logger?.LogDebug($"[{PrinterName}] Started Monitoring.");
                 ReadBuffer = new ConcurrentQueue<byte>();
 
                 _readCancellationTokenSource = new CancellationTokenSource();
@@ -219,7 +219,7 @@ namespace ESCPOS_NET
                 if (connectedStatus != lastConnectionStatus)
                 {
 
-                    Logging.Logger.LogDebug($"[{PrinterName}] MonitorConnectivity detected connection status change. Connected: {connectedStatus}.");
+                    Logging.Logger?.LogDebug($"[{PrinterName}] MonitorConnectivity detected connection status change. Connected: {connectedStatus}.");
                     lastConnectionStatus = connectedStatus;
                     Status = new PrinterStatusEventArgs()
                     {
@@ -237,13 +237,13 @@ namespace ESCPOS_NET
                     {
                         //  grab mutexes and check if the system is still connected.
 
-                        Logging.Logger.LogDebug($"[{PrinterName}] MonitorConnectivity polling printer for status.");
+                        Logging.Logger?.LogDebug($"[{PrinterName}] MonitorConnectivity polling printer for status.");
 
                         var acquiredWriteMutex = InstanceWriteLockMutex.WaitOne(3000);
                         var acquiredReadMutex = InstanceReadLockMutex.WaitOne(3000);
                         if (!acquiredWriteMutex || !acquiredReadMutex)
                         {
-                            Logging.Logger.LogError($"[{PrinterName}] Unable to acquire mutexes to poll for status.");
+                            Logging.Logger?.LogError($"[{PrinterName}] Unable to acquire mutexes to poll for status.");
                         }
                         else
                         {
@@ -261,7 +261,7 @@ namespace ESCPOS_NET
                             catch
                             {
                                 connectedStatus = false;
-                                Logging.Logger.LogInformation($"[{PrinterName}] MonitorConnectivity: Detected connection failure.");
+                                Logging.Logger?.LogInformation($"[{PrinterName}] MonitorConnectivity: Detected connection failure.");
                                 Status = new PrinterStatusEventArgs()
                                 {
                                     DeviceIsConnected = false,
@@ -289,12 +289,12 @@ namespace ESCPOS_NET
                 {
                     try
                     {
-                        Logging.Logger.LogInformation($"[{PrinterName}] MonitorConnectivity: Reconnecting...");
+                        Logging.Logger?.LogInformation($"[{PrinterName}] MonitorConnectivity: Reconnecting...");
                         Reconnect();
                     }
                     catch (Exception e)
                     {
-                        Logging.Logger.LogError(e, $"[{PrinterName}] MonitorConnectivity: Unable to reconnect. Trying again...");
+                        Logging.Logger?.LogError(e, $"[{PrinterName}] MonitorConnectivity: Unable to reconnect. Trying again...");
                         lastConnectionStatus = null;
                     }
                     await Task.Delay(3000);
@@ -306,14 +306,14 @@ namespace ESCPOS_NET
         {
             if (_isMonitoring)
             {
-                Logging.Logger.LogDebug($"[{PrinterName}] Stopping Monitoring...");
+                Logging.Logger?.LogDebug($"[{PrinterName}] Stopping Monitoring...");
                 ReadBuffer = new ConcurrentQueue<byte>();
 
                 if (_readCancellationTokenSource != null)
                 {
                     _readCancellationTokenSource?.Cancel();
                 }
-                Logging.Logger.LogDebug($"[{PrinterName}] Stopped Monitoring.");
+                Logging.Logger?.LogDebug($"[{PrinterName}] Stopped Monitoring.");
                 _isMonitoring = false;
             }
         }
@@ -348,7 +348,7 @@ namespace ESCPOS_NET
                 index++;
             }
 
-            Logging.Logger.LogDebug($"[{PrinterName}] TryUpdatePrinterStatus: {bytesToString}");
+            Logging.Logger?.LogDebug($"[{PrinterName}] TryUpdatePrinterStatus: {bytesToString}");
 
             // Check header bits 0, 1 and 7 are 0, and 4 is 1
             if (bytes[0].IsBitNotSet(0) && bytes[0].IsBitNotSet(1) && bytes[0].IsBitSet(4) && bytes[0].IsBitNotSet(7))
@@ -375,7 +375,7 @@ namespace ESCPOS_NET
 
             if (StatusChanged != null)
             {
-                Logging.Logger.LogDebug($"[{PrinterName}] Invoking Status Changed Event Handler...");
+                Logging.Logger?.LogDebug($"[{PrinterName}] Invoking Status Changed Event Handler...");
                 StatusChanged?.Invoke(this, Status);
             }
         }
@@ -410,7 +410,7 @@ namespace ESCPOS_NET
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.LogDebug(e, $"[{PrinterName}] Dispose Issue during cancellation token cancellation call.");
+                    Logging.Logger?.LogDebug(e, $"[{PrinterName}] Dispose Issue during cancellation token cancellation call.");
                 }
                 try
                 {
@@ -418,7 +418,7 @@ namespace ESCPOS_NET
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.LogDebug(e, $"[{PrinterName}] Dispose Issue closing reader.");
+                    Logging.Logger?.LogDebug(e, $"[{PrinterName}] Dispose Issue closing reader.");
                 }
                 try
                 {
@@ -426,7 +426,7 @@ namespace ESCPOS_NET
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.LogDebug(e, $"[{PrinterName}] Dispose Issue disposing reader.");
+                    Logging.Logger?.LogDebug(e, $"[{PrinterName}] Dispose Issue disposing reader.");
                 }
                 try
                 {
@@ -434,7 +434,7 @@ namespace ESCPOS_NET
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.LogDebug(e, $"[{PrinterName}] Dispose Issue closing writer.");
+                    Logging.Logger?.LogDebug(e, $"[{PrinterName}] Dispose Issue closing writer.");
                 }
                 try
                 {
@@ -442,7 +442,7 @@ namespace ESCPOS_NET
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.LogDebug(e, $"[{PrinterName}] Dispose Issue disposing writer.");
+                    Logging.Logger?.LogDebug(e, $"[{PrinterName}] Dispose Issue disposing writer.");
                 }
                 try
                 {
@@ -450,7 +450,7 @@ namespace ESCPOS_NET
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.LogDebug(e, $"[{PrinterName}] Dispose Issue during overridable dispose.");
+                    Logging.Logger?.LogDebug(e, $"[{PrinterName}] Dispose Issue during overridable dispose.");
                 }
             }
 

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -66,7 +66,6 @@ namespace ESCPOS_NET
         private void Init()
         {
 
-            Status.DeviceIsConnected = false;
             _connectivityCancellationTokenSource = new CancellationTokenSource();
             _readCancellationTokenSource = new CancellationTokenSource();
             _writeCancellationTokenSource = new CancellationTokenSource();
@@ -78,15 +77,14 @@ namespace ESCPOS_NET
             Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Task Threads started", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
         }
 
+
         protected void InvokeConnect()
         {
-            Status.DeviceIsConnected = true;
-            Task.Run(() => StatusChanged?.Invoke(this, Status));
+            Task.Run(() => Connected?.Invoke(this, new ConnectionEventArgs() { IsConnected = true }));
         }
         protected void InvokeDisconnect()
         {
-            Status.DeviceIsConnected = false;
-            Task.Run(() => StatusChanged?.Invoke(this, Status));
+            Task.Run(() => Disconnected?.Invoke(this, new ConnectionEventArgs() { IsConnected = false }));
         }
 
         protected virtual void Reconnect()

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -12,7 +12,7 @@ using System.Timers;
 
 namespace ESCPOS_NET
 {
-    public abstract partial class BasePrinter : IDisposable
+    public abstract partial class BasePrinter : IPrinter, IDisposable
     {
         private bool disposed = false;
 
@@ -38,7 +38,7 @@ namespace ESCPOS_NET
 
         protected ConcurrentQueue<byte> ReadBuffer { get; set; } = new ConcurrentQueue<byte>();
 
-        protected ConcurrentQueue<byte> WriteBuffer { get; set; } = new ConcurrentQueue<byte>();
+        protected ConcurrentQueue<byte[]> WriteBuffer { get; set; } = new ConcurrentQueue<byte[]>();
 
         protected int BytesWrittenSinceLastFlush { get; set; } = 0;
 
@@ -64,7 +64,7 @@ namespace ESCPOS_NET
             // Implemented in the network printer
         }
 
-        public virtual void Read()
+        protected virtual void Read()
         {
             while (_isMonitoring)
             {
@@ -125,6 +125,8 @@ namespace ESCPOS_NET
 
         public virtual void Write(byte[] bytes)
         {
+
+
             if (!IsConnected)
             {
                 Logging.Logger?.LogInformation($"[{PrinterName}] Attempted to write but printer isn't connected. Attempting to reconnect...");

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -78,7 +78,7 @@ namespace ESCPOS_NET
         {
             // Implemented in the network printer
         }
-        protected virtual void WriteLongRunningTask()
+        protected virtual async void WriteLongRunningTask()
         {
             while (true)
             {
@@ -106,10 +106,11 @@ namespace ESCPOS_NET
                     // Swallow the exception
                     Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.");
                 }
+                await Task.Delay(50);
             }
         }
 
-        protected virtual void ReadLongRunningTask()
+        protected virtual async void ReadLongRunningTask()
         {
             while (true)
             {
@@ -150,6 +151,8 @@ namespace ESCPOS_NET
                     // default is 90 seconds
                     Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing IOException... sometimes happens with network printers. Should get reconnected automatically.");
                     //TODO: reconnect socket here.
+
+                    await Task.Delay(250);
                     Reconnect();
                 }
                 catch (Exception ex)
@@ -157,6 +160,7 @@ namespace ESCPOS_NET
                     // Swallow the exception
                     Logging.Logger?.LogDebug($"[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.");
                 }
+                await Task.Delay(50);
             }
         }
 

--- a/ESCPOS_NET/Printers/ConnectionEventArgs.cs
+++ b/ESCPOS_NET/Printers/ConnectionEventArgs.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ESCPOS_NET
+{
+    public class ConnectionEventArgs : EventArgs
+    {
+        public bool IsConnected;
+    }
+}

--- a/ESCPOS_NET/Printers/IPrinter.cs
+++ b/ESCPOS_NET/Printers/IPrinter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace ESCPOS_NET
+{
+    public interface IPrinter
+    {
+        PrinterStatusEventArgs GetStatus();
+        void Write(params byte[][] arrays);
+        void Write(byte[] bytes);
+        event EventHandler StatusChanged;
+        event EventHandler Disconnected;
+        event EventHandler Connected;
+        event EventHandler WriteFailed;
+        event EventHandler Idle;
+        //event EventHandler IdleDisconnected; is this useful? to know that it disconnected because of idle? probably better to have this as info in disconnected event object instead.
+    }
+}

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 
 namespace ESCPOS_NET
 {
@@ -89,6 +90,7 @@ namespace ESCPOS_NET
 
         protected override void Reconnect()
         {
+            if (_settings == null) return;
             if (!_settings.ReconnectOnTimeout)
             {
                 Logging.Logger?.LogInformation($"[{PrinterName}] Reconnect: Settings have disabled reconnection, skipping reconnect attempt.");
@@ -192,6 +194,7 @@ namespace ESCPOS_NET
                 if (_settings.ReconnectOnTimeout && (_settings.MaxReconnectAttempts == null && reconnectAttempts < 100) || reconnectAttempts < _settings.MaxReconnectAttempts)
                 {
                     _isConnecting = false;
+                    Thread.Sleep(250);
                     Reconnect();
                 }
             }

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -16,6 +16,7 @@ namespace ESCPOS_NET
         public uint? ConnectTimeoutMs;
         public uint? ReconnectTimeoutMs;
         public uint? MaxReconnectAttempts;
+        public string PrinterName;
     }
     public class NetworkPrinter : BasePrinter
     {
@@ -45,7 +46,7 @@ namespace ESCPOS_NET
             }
         }
 
-        public NetworkPrinter(NetworkPrinterSettings settings) : base()
+        public NetworkPrinter(NetworkPrinterSettings settings) : base(settings.PrinterName)
         {
             _settings = settings;
             Connect();
@@ -90,12 +91,12 @@ namespace ESCPOS_NET
         {
             if (!_settings.ReconnectOnTimeout)
             {
-                Logging.Logger.LogInformation($"[{PrinterId}] Reconnect: Settings have disabled reconnection, skipping reconnect attempt.");
+                Logging.Logger.LogInformation($"[{PrinterName}] Reconnect: Settings have disabled reconnection, skipping reconnect attempt.");
                 return;
             }
 
             reconnectAttempts += 1;
-            Logging.Logger.LogTrace($"[{PrinterId}] Reconnect: Reconnection attempt {reconnectAttempts}.");
+            Logging.Logger.LogTrace($"[{PrinterName}] Reconnect: Reconnection attempt {reconnectAttempts}.");
 
             try
             {
@@ -103,7 +104,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterId}] Reconnect: Issue stopping monitoring.");
+                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue stopping monitoring.");
             }
             try
             {
@@ -111,7 +112,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterId}] Reconnect: Issue flushing writer.");
+                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue flushing writer.");
             }
             try
             {
@@ -119,7 +120,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterId}] Reconnect: Issue closing writer.");
+                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing writer.");
             }
             try
             {
@@ -127,7 +128,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterId}] Reconnect: Issue closing reader.");
+                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing reader.");
             }
             try
             {
@@ -135,7 +136,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterId}] Reconnect: Issue closing socket stream.");
+                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket stream.");
             }
             try
             {
@@ -143,16 +144,16 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterId}] Reconnect: Issue closing socket.");
+                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket.");
             }
             try
             {
-                Logging.Logger.LogDebug($"[{PrinterId}] Reconnect: Attempting to reconnect...");
+                Logging.Logger.LogDebug($"[{PrinterName}] Reconnect: Attempting to reconnect...");
                 Connect();
             }
             catch (Exception e)
             {
-                Logging.Logger.LogError(e, $"[{PrinterId}] Reconnect: Failed to reconnect.");
+                Logging.Logger.LogError(e, $"[{PrinterName}] Reconnect: Failed to reconnect.");
                 throw;
             }
         }
@@ -169,6 +170,7 @@ namespace ESCPOS_NET
 
             _socket = new Socket(_settings.EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             _socket.SendTimeout = (int)(_settings.SendTimeoutMs ?? 3000);
+            _socket.ReceiveTimeout = (int)(_settings.ReceiveTimeoutMs ?? 750);
             _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
 
 
@@ -187,11 +189,11 @@ namespace ESCPOS_NET
                 Writer = new BinaryWriter(_sockStream, new UTF8Encoding(), true);
                 Reader = new BinaryReader(_sockStream, new UTF8Encoding(), true);
 
-                Logging.Logger.LogDebug($"[{PrinterId}] Connect: Successfully connected.");
+                Logging.Logger.LogDebug($"[{PrinterName}] Connect: Successfully connected.");
 
                 reconnectAttempts = 0;
                 _isConnecting = false;
-                StartMonitoring();
+                // StartMonitoring();
             }
             else
             {

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -3,6 +3,7 @@ using SimpleTcp;
 using System;
 using System.IO;
 using System.Net;
+using System.Text.Json;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -12,14 +13,14 @@ namespace ESCPOS_NET
 {
     public class NetworkPrinterSettings
     {
-        public IPEndPoint EndPoint;
-        public bool ReconnectOnTimeout;
-        public uint? ReceiveTimeoutMs;
-        public uint? SendTimeoutMs;
-        public uint? ConnectTimeoutMs;
-        public uint? ReconnectTimeoutMs;
-        public uint? MaxReconnectAttempts;
-        public string PrinterName;
+        public IPEndPoint EndPoint { get; set; }
+        //public bool ReconnectOnTimeout { get; set; }
+        //public uint? ReceiveTimeoutMs { get; set; }
+        //public uint? SendTimeoutMs { get; set; }
+        //public uint? ConnectTimeoutMs { get; set; }
+        //public uint? ReconnectTimeoutMs { get; set; }
+        //public uint? MaxReconnectAttempts { get; set; }
+        public string PrinterName { get; set; }
     }
     public class NetworkPrinter : BasePrinter
     {

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -41,70 +41,6 @@ namespace ESCPOS_NET
             Task.Run(() => Connect());
         }
 
-        //protected override void Reconnect()
-        //{
-        //    if (_settings == null) return;
-        //    if (!_settings.ReconnectOnTimeout)
-        //    {
-        //        Logging.Logger?.LogInformation($"[{PrinterName}] Reconnect: Settings have disabled reconnection, skipping reconnect attempt.");
-        //        return;
-        //    }
-
-        //    reconnectAttempts += 1;
-        //    Logging.Logger?.LogTrace($"[{PrinterName}] Reconnect: Reconnection attempt {reconnectAttempts}.");
-        //    // TODO: implement simple TCP
-        //    try
-        //    {
-        //        Writer?.Flush();
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue flushing writer.");
-        //    }
-        //    try
-        //    {
-        //        Writer?.Close();
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing writer.");
-        //    }
-        //    try
-        //    {
-        //        Reader?.Close();
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing reader.");
-        //    }
-        //    try
-        //    {
-        //        _sockStream?.Close();
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket stream.");
-        //    }
-        //    try
-        //    {
-        //        _socket?.Close();
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket.");
-        //    }
-        //    try
-        //    {
-        //        Logging.Logger?.LogDebug($"[{PrinterName}] Reconnect: Attempting to reconnect...");
-        //        Connect();
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        Logging.Logger?.LogError(e, $"[{PrinterName}] Reconnect: Failed to reconnect.");
-        //        throw;
-        //    }
-        //}
-
         private void Connected(object sender, ClientConnectedEventArgs e)
         {
             _isConnected = true;
@@ -114,10 +50,6 @@ namespace ESCPOS_NET
             _isConnected = false;
             // Invoke reconnect attempt in a background thread so we don't block the event handler thread.
             Task.Run(() => { AttemptReconnectInfinitely(); });
-
-        }
-        private void DataReceived(object sender, DataReceivedEventArgs e)
-        {
 
         }
         private void AttemptReconnectInfinitely()
@@ -147,14 +79,6 @@ namespace ESCPOS_NET
 
             AttemptReconnectInfinitely();
 
-            // let's go!
-            // Attempt to connect for 5 minutes. If it fails, try again.
-            // TODO: adapt binaryreader and binarywriter to the SimpleClient so that when 
-            // DataReceived is fired or when write is called it will send it to the client lib (SendAsync)
-
-            //// Need to review the parameters set here
-            //Writer = new BinaryWriter(_sockStream, new UTF8Encoding(), true);
-            //Reader = new BinaryReader(_sockStream, new UTF8Encoding(), true);
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -44,11 +44,14 @@ namespace ESCPOS_NET
 
         private void Connected(object sender, ClientConnectedEventArgs e)
         {
+            Logging.Logger?.LogInformation("[{PrinterName}] [{Function}]: Connected successfully to network printer! Settings: {Settings}", PrinterName, "Connected", JsonSerializer.Serialize(_settings));
             _isConnected = true;
         }
         private void Disconnected(object sender, ClientDisconnectedEventArgs e)
         {
             _isConnected = false;
+            Logging.Logger?.LogWarning("[{PrinterName}] [{Function}]: Network printer connection terminated. Attempting to reconnect. Settings: {Settings}", PrinterName, "Disconnected", JsonSerializer.Serialize(_settings));
+            //    Logging.Logger?.LogTrace($"[{PrinterName}] Reconnect: Reconnection attempt {reconnectAttempts}.");
             // Invoke reconnect attempt in a background thread so we don't block the event handler thread.
             Task.Run(() => { AttemptReconnectInfinitely(); });
 
@@ -57,10 +60,13 @@ namespace ESCPOS_NET
         {
             try
             {
-                _tcpConnection.ConnectWithRetries(60000);
+                //_tcpConnection.ConnectWithRetries(300000);
+                _tcpConnection.ConnectWithRetries(3000);
             }
             catch (TimeoutException)
             {
+                Logging.Logger?.LogWarning("[{PrinterName}] [{Function}]: Network printer unable to connect after 5 minutes. Attempting to reconnect. Settings: {Settings}", PrinterName, "AttemptReconnectInfinitely", JsonSerializer.Serialize(_settings));
+
                 Task.Run(async () => { await Task.Delay(250); AttemptReconnectInfinitely(); });
             }
         }

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -136,7 +136,7 @@ namespace ESCPOS_NET
                 _socket.EndConnect(result);
                 _sockStream = new NetworkStream(_socket);
 
-                // Need to review the paramaters set here
+                // Need to review the parameters set here
                 Writer = new BinaryWriter(_sockStream, new UTF8Encoding(), true);
                 Reader = new BinaryReader(_sockStream, new UTF8Encoding(), true);
                 Console.WriteLine("Connected!");

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -16,6 +16,8 @@ namespace ESCPOS_NET
     {
         // Connection string is of the form printer_name:port or ip:port
         public string ConnectionString { get; set; }
+        public EventHandler ConnectedHandler { get; set; }
+        public EventHandler DisconnectedHandler { get; set; }
         //public bool ReconnectOnTimeout { get; set; }
         //public uint? ReceiveTimeoutMs { get; set; }
         //public uint? SendTimeoutMs { get; set; }
@@ -32,12 +34,20 @@ namespace ESCPOS_NET
         public NetworkPrinter(NetworkPrinterSettings settings) : base(settings.PrinterName)
         {
             _settings = settings;
+            if (settings.ConnectedHandler != null)
+            {
+                Connected += settings.ConnectedHandler;
+            }
+            if (settings.DisconnectedHandler != null)
+            {
+                Disconnected += settings.DisconnectedHandler;
+            }
             Connect();
         }
 
         private void ConnectedEvent(object sender, ClientConnectedEventArgs e)
         {
-            Logging.Logger?.LogInformation("[{Function}]:[{PrinterName}] Connected successfully to network printer! Settings: {Settings}", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName, JsonSerializer.Serialize(_settings));
+            Logging.Logger?.LogInformation("[{Function}]:[{PrinterName}] Connected successfully to network printer! Connection String: {ConnectionString}", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName, _settings.ConnectionString);
             IsConnected = true;
             InvokeConnect();
         }
@@ -45,7 +55,7 @@ namespace ESCPOS_NET
         {
             IsConnected = false;
             InvokeDisconnect();
-            Logging.Logger?.LogWarning("[{Function}]:[{PrinterName}] Network printer connection terminated. Attempting to reconnect. Settings: {Settings}", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName, JsonSerializer.Serialize(_settings));
+            Logging.Logger?.LogWarning("[{Function}]:[{PrinterName}] Network printer connection terminated. Attempting to reconnect. Connection String: {ConnectionString}", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName, _settings.ConnectionString);
             Connect();
         }
         private void AttemptReconnectInfinitely()

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
+using SimpleTcp;
 using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace ESCPOS_NET
 {
@@ -26,178 +28,128 @@ namespace ESCPOS_NET
         private NetworkStream _sockStream;
         private int reconnectAttempts = 0;
         private volatile bool _isConnecting = false;
+        private SimpleTcpClient _client;
 
+        private bool _isConnected = false;
         protected override bool IsConnected
         {
             get
             {
-                if (_socket == null) return false;
-                if (_isConnecting) return false;
-                if (!_socket.Connected) return false;
-
-                try
-                {
-                    return !(_socket.Poll(1, SelectMode.SelectRead) && _socket.Available == 0);
-                }
-                catch (Exception e)
-                {
-                    Logging.Logger?.LogDebug(e, "IsConnected returning false due to connection issue.");
-                    return false;
-                }
+                return _isConnected;
             }
         }
 
         public NetworkPrinter(NetworkPrinterSettings settings) : base(settings.PrinterName)
         {
             _settings = settings;
-            Connect();
+            Task.Run(() => Connect(settings));
         }
 
-        public NetworkPrinter(IPEndPoint endPoint, bool reconnectOnTimeout)
-            : base()
+        //protected override void Reconnect()
+        //{
+        //    if (_settings == null) return;
+        //    if (!_settings.ReconnectOnTimeout)
+        //    {
+        //        Logging.Logger?.LogInformation($"[{PrinterName}] Reconnect: Settings have disabled reconnection, skipping reconnect attempt.");
+        //        return;
+        //    }
+
+        //    reconnectAttempts += 1;
+        //    Logging.Logger?.LogTrace($"[{PrinterName}] Reconnect: Reconnection attempt {reconnectAttempts}.");
+        //    // TODO: implement simple TCP
+        //    try
+        //    {
+        //        Writer?.Flush();
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue flushing writer.");
+        //    }
+        //    try
+        //    {
+        //        Writer?.Close();
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing writer.");
+        //    }
+        //    try
+        //    {
+        //        Reader?.Close();
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing reader.");
+        //    }
+        //    try
+        //    {
+        //        _sockStream?.Close();
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket stream.");
+        //    }
+        //    try
+        //    {
+        //        _socket?.Close();
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket.");
+        //    }
+        //    try
+        //    {
+        //        Logging.Logger?.LogDebug($"[{PrinterName}] Reconnect: Attempting to reconnect...");
+        //        Connect();
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        Logging.Logger?.LogError(e, $"[{PrinterName}] Reconnect: Failed to reconnect.");
+        //        throw;
+        //    }
+        //}
+
+        private void Connected(object sender, ClientConnectedEventArgs e)
         {
-            _settings = new NetworkPrinterSettings()
-            {
-                EndPoint = endPoint,
-                ReconnectOnTimeout = reconnectOnTimeout,
-            };
-            Connect();
+            _isConnected = true;
+        }
+        private void Disconnected(object sender, ClientDisconnectedEventArgs e)
+        {
+            _isConnected = false;
+
+        }
+        private void DataReceived(object sender, DataReceivedEventArgs e)
+        {
+
         }
 
-        public NetworkPrinter(IPAddress ipAddress, int port, bool reconnectOnTimeout)
-            : base()
-        {
-            var endPoint = new IPEndPoint(ipAddress, port);
-            _settings = new NetworkPrinterSettings()
-            {
-                EndPoint = endPoint,
-                ReconnectOnTimeout = reconnectOnTimeout,
-            };
-            Connect();
-        }
-
-        public NetworkPrinter(string ipAddress, int port, bool reconnectOnTimeout)
-            : base()
-        {
-            var endPoint = new IPEndPoint(IPAddress.Parse(ipAddress), port);
-            _settings = new NetworkPrinterSettings()
-            {
-                EndPoint = endPoint,
-                ReconnectOnTimeout = reconnectOnTimeout,
-            };
-            Connect();
-        }
-
-        protected override void Reconnect()
-        {
-            if (_settings == null) return;
-            if (!_settings.ReconnectOnTimeout)
-            {
-                Logging.Logger?.LogInformation($"[{PrinterName}] Reconnect: Settings have disabled reconnection, skipping reconnect attempt.");
-                return;
-            }
-
-            reconnectAttempts += 1;
-            Logging.Logger?.LogTrace($"[{PrinterName}] Reconnect: Reconnection attempt {reconnectAttempts}.");
-            // TODO: implement simple TCP
-            try
-            {
-                Writer?.Flush();
-            }
-            catch (Exception e)
-            {
-                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue flushing writer.");
-            }
-            try
-            {
-                Writer?.Close();
-            }
-            catch (Exception e)
-            {
-                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing writer.");
-            }
-            try
-            {
-                Reader?.Close();
-            }
-            catch (Exception e)
-            {
-                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing reader.");
-            }
-            try
-            {
-                _sockStream?.Close();
-            }
-            catch (Exception e)
-            {
-                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket stream.");
-            }
-            try
-            {
-                _socket?.Close();
-            }
-            catch (Exception e)
-            {
-                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket.");
-            }
-            try
-            {
-                Logging.Logger?.LogDebug($"[{PrinterName}] Reconnect: Attempting to reconnect...");
-                Connect();
-            }
-            catch (Exception e)
-            {
-                Logging.Logger?.LogError(e, $"[{PrinterName}] Reconnect: Failed to reconnect.");
-                throw;
-            }
-        }
-
-        private void Connect()
+        private void Connect(NetworkPrinterSettings settings)
         {
 
-            // Allow cooperative threads to check volatile bool to see if we are currently processing the socket
-            // and it's not readable (for example, the IsConnected property).
-            if (_isConnecting) return;
-            _isConnecting = true;
+            // instantiate
+            _client = new SimpleTcpClient(settings.EndPoint.ToString());
 
+            // set events
+            _client.Events.Connected += Connected;
+            _client.Events.Disconnected += Disconnected;
+            _client.Events.DataReceived += DataReceived;
 
-            _socket = new Socket(_settings.EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            _socket.SendTimeout = (int)(_settings.SendTimeoutMs ?? 3000);
-            _socket.ReceiveTimeout = (int)(_settings.ReceiveTimeoutMs ?? 750);
-            _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-
-
-            var socketArgs = new SocketAsyncEventArgs();
-
-            IAsyncResult result = _socket.BeginConnect(_settings.EndPoint, null, null);
-
-            bool success = result.AsyncWaitHandle.WaitOne((int)(_settings.ConnectTimeoutMs ?? 10000), true);
-
-            if (_socket.Connected)
+            // let's go!
+            // Attempt to connect for 5 minutes. If it fails, try again.
+            try
             {
-                _socket.EndConnect(result);
-                _sockStream = new NetworkStream(_socket);
-
-                // Need to review the parameters set here
-                Writer = new BinaryWriter(_sockStream, new UTF8Encoding(), true);
-                Reader = new BinaryReader(_sockStream, new UTF8Encoding(), true);
-
-                Logging.Logger?.LogDebug($"[{PrinterName}] Connect: Successfully connected.");
-
-                reconnectAttempts = 0;
-                _isConnecting = false;
-                // StartMonitoring();
+                _client.ConnectWithRetries(20);
             }
-            else
+            catch (TimeoutException ex)
             {
-                _socket.Close();
-                if (_settings.ReconnectOnTimeout && (_settings.MaxReconnectAttempts == null && reconnectAttempts < 100) || reconnectAttempts < _settings.MaxReconnectAttempts)
-                {
-                    _isConnecting = false;
-                    Thread.Sleep(250);
-                    Reconnect();
-                }
+
             }
+            // TODO: adapt binaryreader and binarywriter to the SimpleClient so that when 
+            // DataReceived is fired or when write is called it will send it to the client lib (SendAsync)
+
+                //// Need to review the parameters set here
+                //Writer = new BinaryWriter(_sockStream, new UTF8Encoding(), true);
+                //Reader = new BinaryReader(_sockStream, new UTF8Encoding(), true);
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -40,7 +40,7 @@ namespace ESCPOS_NET
                 }
                 catch (Exception e)
                 {
-                    Logging.Logger.LogDebug(e, "IsConnected returning false due to connection issue.");
+                    Logging.Logger?.LogDebug(e, "IsConnected returning false due to connection issue.");
                     return false;
                 }
             }
@@ -91,12 +91,12 @@ namespace ESCPOS_NET
         {
             if (!_settings.ReconnectOnTimeout)
             {
-                Logging.Logger.LogInformation($"[{PrinterName}] Reconnect: Settings have disabled reconnection, skipping reconnect attempt.");
+                Logging.Logger?.LogInformation($"[{PrinterName}] Reconnect: Settings have disabled reconnection, skipping reconnect attempt.");
                 return;
             }
 
             reconnectAttempts += 1;
-            Logging.Logger.LogTrace($"[{PrinterName}] Reconnect: Reconnection attempt {reconnectAttempts}.");
+            Logging.Logger?.LogTrace($"[{PrinterName}] Reconnect: Reconnection attempt {reconnectAttempts}.");
 
             try
             {
@@ -104,7 +104,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue stopping monitoring.");
+                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue stopping monitoring.");
             }
             try
             {
@@ -112,7 +112,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue flushing writer.");
+                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue flushing writer.");
             }
             try
             {
@@ -120,7 +120,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing writer.");
+                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing writer.");
             }
             try
             {
@@ -128,7 +128,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing reader.");
+                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing reader.");
             }
             try
             {
@@ -136,7 +136,7 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket stream.");
+                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket stream.");
             }
             try
             {
@@ -144,16 +144,16 @@ namespace ESCPOS_NET
             }
             catch (Exception e)
             {
-                Logging.Logger.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket.");
+                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue closing socket.");
             }
             try
             {
-                Logging.Logger.LogDebug($"[{PrinterName}] Reconnect: Attempting to reconnect...");
+                Logging.Logger?.LogDebug($"[{PrinterName}] Reconnect: Attempting to reconnect...");
                 Connect();
             }
             catch (Exception e)
             {
-                Logging.Logger.LogError(e, $"[{PrinterName}] Reconnect: Failed to reconnect.");
+                Logging.Logger?.LogError(e, $"[{PrinterName}] Reconnect: Failed to reconnect.");
                 throw;
             }
         }
@@ -189,7 +189,7 @@ namespace ESCPOS_NET
                 Writer = new BinaryWriter(_sockStream, new UTF8Encoding(), true);
                 Reader = new BinaryReader(_sockStream, new UTF8Encoding(), true);
 
-                Logging.Logger.LogDebug($"[{PrinterName}] Connect: Successfully connected.");
+                Logging.Logger?.LogDebug($"[{PrinterName}] Connect: Successfully connected.");
 
                 reconnectAttempts = 0;
                 _isConnecting = false;

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -97,15 +97,7 @@ namespace ESCPOS_NET
 
             reconnectAttempts += 1;
             Logging.Logger?.LogTrace($"[{PrinterName}] Reconnect: Reconnection attempt {reconnectAttempts}.");
-
-            try
-            {
-                StopMonitoring();
-            }
-            catch (Exception e)
-            {
-                Logging.Logger?.LogDebug(e, $"[{PrinterName}] Reconnect: Issue stopping monitoring.");
-            }
+            // TODO: implement simple TCP
             try
             {
                 Writer?.Flush();
@@ -166,7 +158,6 @@ namespace ESCPOS_NET
             if (_isConnecting) return;
             _isConnecting = true;
 
-            StopMonitoring();
 
             _socket = new Socket(_settings.EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             _socket.SendTimeout = (int)(_settings.SendTimeoutMs ?? 3000);

--- a/ESCPOS_NET/Printers/PrinterOptions.cs
+++ b/ESCPOS_NET/Printers/PrinterOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace ESCPOS_NET
+{
+    public class PrinterOptions
+    {
+        int IdleTimeoutSeconds { get; set; } = 60;
+        int StatusPollingIntervalMilliseconds { get; set; }  = 500;
+    }
+}

--- a/ESCPOS_NET/Printers/PrinterStatusEventArgs.cs
+++ b/ESCPOS_NET/Printers/PrinterStatusEventArgs.cs
@@ -30,6 +30,5 @@ namespace ESCPOS_NET
 
         public bool? DidRecoverableNonAutocutterErrorOccur { get; set; }
 
-        public bool? DeviceIsConnected { get; set; }
     }
 }

--- a/ESCPOS_NET/Printers/PrinterStatusEventArgs.cs
+++ b/ESCPOS_NET/Printers/PrinterStatusEventArgs.cs
@@ -30,6 +30,6 @@ namespace ESCPOS_NET
 
         public bool DidRecoverableNonAutocutterErrorOccur { get; set; }
 
-        public bool DeviceConnectionTimeout { get; set; }
+        public bool DeviceIsConnected { get; set; }
     }
 }

--- a/ESCPOS_NET/Printers/PrinterStatusEventArgs.cs
+++ b/ESCPOS_NET/Printers/PrinterStatusEventArgs.cs
@@ -4,32 +4,32 @@ namespace ESCPOS_NET
 {
     public class PrinterStatusEventArgs : EventArgs
     {
-        public bool IsWaitingForOnlineRecovery { get; set; }
+        public bool? IsWaitingForOnlineRecovery { get; set; }
 
-        public bool IsPaperCurrentlyFeeding { get; set; }
+        public bool? IsPaperCurrentlyFeeding { get; set; }
 
-        public bool IsPaperFeedButtonPushed { get; set; }
+        public bool? IsPaperFeedButtonPushed { get; set; }
 
-        public bool IsPrinterOnline { get; set; }
+        public bool? IsPrinterOnline { get; set; }
 
-        public bool IsCashDrawerOpen { get; set; }
+        public bool? IsCashDrawerOpen { get; set; }
 
-        public bool IsCoverOpen { get; set; }
+        public bool? IsCoverOpen { get; set; }
 
-        public bool IsPaperLow { get; set; }
+        public bool? IsPaperLow { get; set; }
 
-        public bool IsPaperOut { get; set; }
+        public bool? IsPaperOut { get; set; }
 
-        public bool IsInErrorState => DidRecoverableErrorOccur || DidUnrecoverableErrorOccur || DidAutocutterErrorOccur || DidRecoverableNonAutocutterErrorOccur;
+        public bool? IsInErrorState => (DidRecoverableErrorOccur ?? false) || (DidUnrecoverableErrorOccur ?? false) || (DidAutocutterErrorOccur ?? false) || (DidRecoverableNonAutocutterErrorOccur ?? false);
 
-        public bool DidRecoverableErrorOccur { get; set; }
+        public bool? DidRecoverableErrorOccur { get; set; }
 
-        public bool DidUnrecoverableErrorOccur { get; set; }
+        public bool? DidUnrecoverableErrorOccur { get; set; }
 
-        public bool DidAutocutterErrorOccur { get; set; }
+        public bool? DidAutocutterErrorOccur { get; set; }
 
-        public bool DidRecoverableNonAutocutterErrorOccur { get; set; }
+        public bool? DidRecoverableNonAutocutterErrorOccur { get; set; }
 
-        public bool DeviceIsConnected { get; set; }
+        public bool? DeviceIsConnected { get; set; }
     }
 }

--- a/ESCPOS_NET/Utils/Consts.cs
+++ b/ESCPOS_NET/Utils/Consts.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ESCPOS_NET.Utils
+{
+    public static class Consts
+    {
+        public static readonly string LIBNAME = "ESCPOS_NET";
+    }
+}

--- a/ESCPOS_NET/Utils/EchoStream.cs
+++ b/ESCPOS_NET/Utils/EchoStream.cs
@@ -1,0 +1,185 @@
+﻿
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Collections.Concurrent;
+
+namespace ESCPOS_NET.Utils
+{
+
+    public class EchoStream : Stream
+    {
+        public override bool CanTimeout { get; } = true;
+        public override int ReadTimeout { get; set; } = Timeout.Infinite;
+        public override int WriteTimeout { get; set; } = Timeout.Infinite;
+        public override bool CanRead { get; } = true;
+        public override bool CanSeek { get; } = false;
+        public override bool CanWrite { get; } = true;
+
+        public bool CopyBufferOnWrite { get; set; } = false;
+
+        private readonly object _lock = new object();
+
+        // Default underlying mechanism for BlockingCollection is ConcurrentQueue<T>, which is what we want
+        private readonly BlockingCollection<byte[]> _Buffers;
+        private int _maxQueueDepth = 10;
+
+        private byte[] m_buffer = null;
+        private int m_offset = 0;
+        private int m_count = 0;
+
+        private bool m_Closed = false;
+        public override void Close()
+        {
+            m_Closed = true;
+
+            // release any waiting writes
+            _Buffers.CompleteAdding();
+        }
+
+        public bool DataAvailable
+        {
+            get
+            {
+                return _Buffers.Count > 0;
+            }
+        }
+
+        private long _Length = 0L;
+        public override long Length
+        {
+            get
+            {
+                return _Length;
+            }
+        }
+
+        private long _Position = 0L;
+        public override long Position
+        {
+            get
+            {
+                return _Position;
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public EchoStream() : this(10)
+        {
+        }
+
+        public EchoStream(int maxQueueDepth)
+        {
+            _maxQueueDepth = maxQueueDepth;
+            _Buffers = new BlockingCollection<byte[]>(_maxQueueDepth);
+        }
+
+        // we override the xxxxAsync functions because the default base class shares state between ReadAsync and WriteAsync, which causes a hang if both are called at once
+        public new Task WriteAsync(byte[] buffer, int offset, int count)
+        {
+            return Task.Run(() => Write(buffer, offset, count));
+        }
+
+        // we override the xxxxAsync functions because the default base class shares state between ReadAsync and WriteAsync, which causes a hang if both are called at once
+        public new Task<int> ReadAsync(byte[] buffer, int offset, int count)
+        {
+            return Task.Run(() =>
+            {
+                return Read(buffer, offset, count);
+            });
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (m_Closed || buffer.Length - offset < count || count <= 0)
+                return;
+
+            byte[] newBuffer;
+            if (!CopyBufferOnWrite && offset == 0 && count == buffer.Length)
+                newBuffer = buffer;
+            else
+            {
+                newBuffer = new byte[count];
+                System.Buffer.BlockCopy(buffer, offset, newBuffer, 0, count);
+            }
+            if (!_Buffers.TryAdd(newBuffer, WriteTimeout))
+                throw new TimeoutException("EchoStream Write() Timeout");
+
+            _Length += count;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (count == 0)
+                return 0;
+            lock (_lock)
+            {
+                if (m_count == 0 && _Buffers.Count == 0)
+                {
+                    if (m_Closed)
+                        return -1;
+
+                    if (_Buffers.TryTake(out m_buffer, ReadTimeout))
+                    {
+                        m_offset = 0;
+                        m_count = m_buffer.Length;
+                    }
+                    else
+                        return m_Closed ? -1 : 0;
+                }
+
+                int returnBytes = 0;
+                while (count > 0)
+                {
+                    if (m_count == 0)
+                    {
+                        if (_Buffers.TryTake(out m_buffer, 0))
+                        {
+                            m_offset = 0;
+                            m_count = m_buffer.Length;
+                        }
+                        else
+                            break;
+                    }
+
+                    var bytesToCopy = (count < m_count) ? count : m_count;
+                    System.Buffer.BlockCopy(m_buffer, m_offset, buffer, offset, bytesToCopy);
+                    m_offset += bytesToCopy;
+                    m_count -= bytesToCopy;
+                    offset += bytesToCopy;
+                    count -= bytesToCopy;
+
+                    returnBytes += bytesToCopy;
+                }
+
+                _Position += returnBytes;
+
+                return returnBytes;
+            }
+        }
+
+        public override int ReadByte()
+        {
+            byte[] returnValue = new byte[1];
+            return (Read(returnValue, 0, 1) <= 0 ? -1 : (int)returnValue[0]);
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ESCPOS_NET/Utils/InterceptableWriteMemoryStream.cs
+++ b/ESCPOS_NET/Utils/InterceptableWriteMemoryStream.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+
+namespace ESCPOS_NET
+{
+    public class InterceptableWriteMemoryStream : Stream
+    {
+        private MemoryStream _innerStream = new MemoryStream();
+        public override bool CanRead => _innerStream.CanRead;
+
+        public override bool CanSeek => _innerStream.CanSeek;
+
+        public override bool CanWrite => _innerStream.CanWrite;
+
+        public override long Length => _innerStream.Length;
+
+        public override long Position { get => _innerStream.Position; set => _innerStream.Position = value; }
+
+        private Action<byte[]> _writeAction { get; set; }
+        public InterceptableWriteMemoryStream(Action<byte[]> writeAction)
+        {
+            _writeAction = writeAction;   
+        }
+        public override void Flush()
+        {
+            _innerStream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _innerStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _innerStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            _innerStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var writeArray = new byte[count];
+            Buffer.BlockCopy(buffer, offset, writeArray, 0, count);
+            _writeAction(writeArray);
+        }
+    }
+}

--- a/ESCPOS_NET/Utils/TCPConnection.cs
+++ b/ESCPOS_NET/Utils/TCPConnection.cs
@@ -1,4 +1,5 @@
-﻿using SimpleTcp;
+﻿using ESCPOS_NET.Utils;
+using SimpleTcp;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,7 +9,7 @@ namespace ESCPOS_NET
 {
     public class TCPConnection
     {
-        public Stream ReadStream { get; private set; } = new MemoryStream();
+        public Stream ReadStream { get; private set; } = new EchoStream();
         public Stream WriteStream { get; private set; }
         public event EventHandler<ClientConnectedEventArgs> Connected;
         public event EventHandler<ClientDisconnectedEventArgs> Disconnected;
@@ -22,6 +23,7 @@ namespace ESCPOS_NET
             _client.Events.Disconnected += DisconnectedEventHandler;
             _client.Events.DataReceived += DataReceivedEventHandler;
             _client.Keepalive = new SimpleTcpKeepaliveSettings() { EnableTcpKeepAlives = true, TcpKeepAliveInterval = 1, TcpKeepAliveTime = 1, TcpKeepAliveRetryCount = 3 };
+            ReadStream.ReadTimeout = 1500;
             WriteStream = new InterceptableWriteMemoryStream(bytes => _client.Send(bytes));
         }
         private void ConnectedEventHandler(object sender, ClientConnectedEventArgs e)

--- a/ESCPOS_NET/Utils/TCPConnection.cs
+++ b/ESCPOS_NET/Utils/TCPConnection.cs
@@ -1,0 +1,54 @@
+﻿using SimpleTcp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace ESCPOS_NET
+{
+    public class TCPConnection
+    {
+        public Stream ReadStream { get; private set; } = new MemoryStream();
+        public Stream WriteStream { get; private set; }
+        public event EventHandler<ClientConnectedEventArgs> Connected;
+        public event EventHandler<ClientDisconnectedEventArgs> Disconnected;
+        public bool IsConnected => _client?.IsConnected ?? false;
+        private SimpleTcpClient _client;
+        //public event EventHandler<DataReceivedEventArgs> DataReceived;
+        public TCPConnection(string destination)
+        {
+            _client = new SimpleTcpClient(destination);
+            _client.Events.Connected += ConnectedEventHandler;
+            _client.Events.Disconnected += DisconnectedEventHandler;
+            _client.Events.DataReceived += DataReceivedEventHandler;
+            _client.Keepalive = new SimpleTcpKeepaliveSettings() { EnableTcpKeepAlives = true, TcpKeepAliveInterval = 1, TcpKeepAliveTime = 1, TcpKeepAliveRetryCount = 3 };
+            WriteStream = new InterceptableWriteMemoryStream(bytes => _client.Send(bytes));
+        }
+        private void ConnectedEventHandler(object sender, ClientConnectedEventArgs e)
+        {
+            Connected?.Invoke(sender, e);
+        }
+        private void DisconnectedEventHandler(object sender, ClientDisconnectedEventArgs e)
+        {
+            Disconnected?.Invoke(sender, e);
+        }
+        private void DataReceivedEventHandler(object sender, DataReceivedEventArgs e)
+        {
+            ReadStream.Write(e.Data, 0, e.Data.Length);
+        }
+        public void ConnectWithRetries(int timeoutMs)
+        {
+            _client.ConnectWithRetries(timeoutMs);
+        }
+
+        ~TCPConnection()
+        {
+            try
+            {
+                _client?.Dispose();
+            }
+            catch { }
+        }
+
+    }
+}

--- a/ESCPOS_NET/Utils/TCPConnection.cs
+++ b/ESCPOS_NET/Utils/TCPConnection.cs
@@ -47,6 +47,9 @@ namespace ESCPOS_NET
         {
             try
             {
+                _client.Events.DataReceived -= DataReceivedEventHandler;
+                _client.Events.Connected -= ConnectedEventHandler;
+                _client.Events.Disconnected -= DisconnectedEventHandler;
                 _client?.Dispose();
             }
             catch { }


### PR DESCRIPTION
SimpleTCP library has been integrated to replace the off the shelf TCP connectivity.  This has been extensively tested to ensure that keepalives function properly, and devices are reconnected if they lose connectivity.  This now lets you connect to a device one time, and it will stay connected (or reconnect) automatically without any separate management of the lifecycle of the connection.