### PR TITLE
Introduce WriteAsync to not swallow all exceptions and improve write performance and misc enhancements

### DIFF
--- a/ESCPOS_NET.ConsoleTest/TestLargeByteArrays.cs
+++ b/ESCPOS_NET.ConsoleTest/TestLargeByteArrays.cs
@@ -35,7 +35,7 @@ namespace ESCPOS_NET.ConsoleTest
                 cube
             );
             MemoryPrinter mp = new MemoryPrinter();
-            mp.Write(expectedResult);
+            mp.WriteTest(expectedResult);
             var response = mp.GetAllData();
             bool hasErrors = false;
             if (expectedResult.Length != response.Length)
@@ -68,7 +68,7 @@ namespace ESCPOS_NET.ConsoleTest
             var filename = $"{r.NextDouble().ToString()}.tmp";
             using (FilePrinter fp = new FilePrinter(filename, true))
             { 
-                fp.Write(expectedResult);
+                fp.WriteTest(expectedResult);
             }
             response = File.ReadAllBytes(filename);
             hasErrors = false;

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -32,10 +32,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.9" />
 		<PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
 		<PackageReference Include="System.IO.Ports" Version="6.0.0" />
-		<PackageReference Include="System.Text.Json" Version="6.0.4" />
+		<PackageReference Include="System.Text.Json" Version="6.0.11" />
 	</ItemGroup>
 
 </Project>

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -42,8 +42,8 @@ namespace ESCPOS_NET
         protected ConcurrentQueue<byte[]> WriteBuffer { get; set; } = new ConcurrentQueue<byte[]>();
 
         protected int BytesWrittenSinceLastFlush { get; set; } = 0;
-
-        protected volatile bool IsConnected  = true;
+        
+        protected virtual bool IsConnected { get; } = true;
 
         public string PrinterName { get; protected set; }
 

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -21,7 +21,6 @@ namespace ESCPOS_NET
         //private volatile bool _isMonitoring;
 
         private CancellationTokenSource _readCancellationTokenSource;
-        private CancellationTokenSource _writeCancellationTokenSource;
 
         private readonly int _maxBytesPerWrite = 15000; // max byte chunks to write at once.
 
@@ -34,18 +33,22 @@ namespace ESCPOS_NET
         //public event EventHandler Idle;
 
         protected BinaryWriter Writer { get; set; }
-
         protected BinaryReader Reader { get; set; }
 
         protected ConcurrentQueue<byte> ReadBuffer { get; set; } = new ConcurrentQueue<byte>();
-
-        protected ConcurrentQueue<byte[]> WriteBuffer { get; set; } = new ConcurrentQueue<byte[]>();
+        private readonly BlockingCollection<(byte[] bytes, TaskCompletionSource<bool> taskSource)> _writeBuffer =
+            new BlockingCollection<(byte[] bytes, TaskCompletionSource<bool> taskSource)>();
 
         protected int BytesWrittenSinceLastFlush { get; set; } = 0;
-        
+
         protected virtual bool IsConnected { get; } = true;
 
         public string PrinterName { get; protected set; }
+
+        /// <summary>
+        /// Timeout in millisecond to wait for the connection to be connected when call WriteAsync function with await. Default is 5000 milliseconds.
+        /// </summary>
+        public int WriteTimeout { get; set; } = 5000;
 
         protected BasePrinter()
         {
@@ -64,10 +67,9 @@ namespace ESCPOS_NET
         private void Init()
         {
             _readCancellationTokenSource = new CancellationTokenSource();
-            _writeCancellationTokenSource = new CancellationTokenSource();
             Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Initializing Task Threads...", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
             //Task.Factory.StartNew(MonitorPrinterStatusLongRunningTask, _connectivityCancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).ConfigureAwait(false);
-            Task.Factory.StartNew(WriteLongRunningTask, _writeCancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).ConfigureAwait(false);
+            Task.Factory.StartNew(WriteLongRunningTask, TaskCreationOptions.LongRunning).ConfigureAwait(false);
             Task.Factory.StartNew(ReadLongRunningTask, _readCancellationTokenSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).ConfigureAwait(false);
             // TODO: read and status monitoring probably won't work for fileprinter, should let printer types disable this feature.
             Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Task Threads started", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
@@ -89,40 +91,52 @@ namespace ESCPOS_NET
         }
         protected virtual async void WriteLongRunningTask()
         {
-            while (true)
+            // Loop when there is a new item in the _writeBuffer, break when _writeBuffer.CompleteAdding() is called (in the dispose)
+            foreach (var (nextBytes, taskSource) in _writeBuffer.GetConsumingEnumerable())
             {
-                if (_writeCancellationTokenSource != null && _writeCancellationTokenSource.IsCancellationRequested)
-                {
-                    Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Write Long-Running Task Cancellation was requested.", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
-                    break;
-                }
+                await Task.WhenAny(
+                    Task.Delay(WriteTimeout),
+                    Task.Run(async () =>
+                    {
+                        while (!IsConnected) // Await for the connection to the printer get restored
+                        {
+                            await Task.Delay(100);
+                        }
+                    })
+                );
 
-                await Task.Delay(100);
                 if (!IsConnected)
                 {
+                    taskSource.SetException(new IOException($"Unrecoverable connectivity error writing to printer."));
                     continue;
                 }
-
                 try
                 {
-                    var didDequeue = WriteBuffer.TryDequeue(out var nextBytes);
-                    if (didDequeue && nextBytes?.Length > 0)
+                    if (nextBytes?.Length > 0)
                     {
                         WriteToBinaryWriter(nextBytes);
+                        taskSource.SetResult(true);
+                    }
+                    else
+                    {
+                        taskSource.SetResult(false);
                     }
                 }
                 catch (IOException ex)
                 {
                     // Thrown if the printer times out the socket connection
                     // default is 90 seconds
+                    taskSource.TrySetException(ex);
                     //Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Swallowing IOException... sometimes happens with network printers. Should get reconnected automatically.");
                 }
                 catch (Exception ex)
                 {
-                    // Swallow the exception
+                    taskSource.TrySetException(ex);
                     //Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.");
                 }
             }
+
+            Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Write Long-Running Task Cancellation was requested.", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
         }
 
         protected virtual async void ReadLongRunningTask()
@@ -151,28 +165,42 @@ namespace ESCPOS_NET
                         DataAvailable();
                     }
                 }
-             
                 catch (Exception ex)
-                {                    
+                {
                     // Swallow the exception
                     //Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
                 }
             }
         }
 
-        public virtual void Write(params byte[][] arrays)
+        ///<inheritdoc/>
+        public virtual void Write(params byte[][] byteArrays)
         {
-            Write(ByteSplicer.Combine(arrays));
+            Write(ByteSplicer.Combine(byteArrays));
         }
 
+        ///<inheritdoc/>
         public virtual void Write(byte[] bytes)
         {
-            WriteBuffer.Enqueue(bytes);
+            _ = WriteAsync(bytes);
+        }
+
+        ///<inheritdoc/>
+        public virtual async Task WriteAsync(params byte[][] byteArrays)
+        {
+            await WriteAsync(ByteSplicer.Combine(byteArrays));
+        }
+
+        ///<inheritdoc/>
+        public virtual async Task WriteAsync(byte[] bytes)
+        {
+            var taskSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _writeBuffer.Add((bytes, taskSource));
+            await taskSource.Task;
         }
 
         protected virtual void WriteToBinaryWriter(byte[] bytes)
         {
-
             if (!IsConnected)
             {
                 Logging.Logger?.LogInformation("[{Function}]:[{PrinterName}] Attempted to write but printer isn't connected. Attempting to reconnect...", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
@@ -190,7 +218,6 @@ namespace ESCPOS_NET
             bool hasFlushed = false;
             while (bytesLeft > 0)
             {
-
                 int count = Math.Min(_maxBytesPerWrite, bytesLeft);
                 try
                 {
@@ -227,7 +254,6 @@ namespace ESCPOS_NET
         {
             try
             {
-
                 BytesWrittenSinceLastFlush = 0;
                 Writer.Flush();
             }
@@ -237,9 +263,9 @@ namespace ESCPOS_NET
             }
         }
 
-        public virtual void DataAvailable()
+        private void DataAvailable()
         {
-            if (ReadBuffer.Count() % 4 == 0)
+            if (ReadBuffer.Count % 4 == 0)
             {
                 var bytes = new byte[4];
                 for (int i = 0; i < 4; i++)
@@ -324,6 +350,14 @@ namespace ESCPOS_NET
                 catch (Exception e)
                 {
                     Logging.Logger?.LogDebug(e, "[{Function}]:[{PrinterName}] Dispose Issue during cancellation token cancellation call.", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
+                }
+                try
+                {
+                    _writeBuffer.CompleteAdding();
+                }
+                catch (ObjectDisposedException e)
+                {
+                    Logging.Logger?.LogDebug(e, "[{Function}]:[{PrinterName}] Dispose Issue during closing write buffer.", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
                 }
                 try
                 {

--- a/ESCPOS_NET/Printers/IPrinter.cs
+++ b/ESCPOS_NET/Printers/IPrinter.cs
@@ -1,12 +1,50 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace ESCPOS_NET
 {
     public interface IPrinter
     {
         PrinterStatusEventArgs GetStatus();
-        void Write(params byte[][] arrays);
+        /// <summary>
+        /// Write byte array of array to the printer stream. This function discards the <see cref="WriteTimeout"/> and the <paramref name="byteArrays"/> parameter will still be written 
+        /// to the printer stream when the connection restored <b>if this instance is disposed yet
+        /// </summary>
+        /// <param name="byteArrays">Array of byte array which to be flattened to the overloaded function.</param>
+        /// <returns></returns>
+        void Write(params byte[][] byteArrays);
+        /// <summary>
+        /// Write byte array of array to the printer stream. This function discards the <see cref="WriteTimeout"/> and the <paramref name="byteArrays"/> parameter will still be written 
+        /// to the printer stream when the connection restored <b>if this instance is disposed yet
+        /// </summary>
+        /// <param name="bytes">Byte array to write to the printer stream.</param>
+        /// <returns></returns>
         void Write(byte[] bytes);
+        /// <summary>
+        /// Write byte array of array to the printer stream.
+        /// </summary>
+        /// <param name="byteArrays">Array of byte array which to be flattened to the overloaded function.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// await or Wait() this function to await the operation and it would properly capture the exception otherwise the exception will be swallowed.
+        /// Not await nor Wait() this function would discard the <see cref="WriteTimeout"/> and the <paramref name="byteArrays"/> parameter will still be written 
+        /// to the printer stream when the connection restored <b>if this instance is disposed yet</b>.
+        /// </remarks>
+        /// <exception cref="IOException">The <see cref="WriteTimeout"/> is reach or Attempt to write stream to the disconnected connection</exception>
+        Task WriteAsync(params byte[][] byteArrays);
+        /// <summary>
+        /// Write byte array of array to the printer stream.
+        /// </summary>
+        /// <param name="bytes">Byte array to write to the printer stream.</param>
+        /// <returns></returns>
+        /// <remarks>
+        /// await or Wait() this function to await the operation and it would properly capture the exception otherwise the exception will be swallowed.
+        /// Not await nor Wait() this function would discard the <see cref="WriteTimeout"/> and the <paramref name="bytes"/> parameter will still be written 
+        /// to the printer stream when the connection restored <b>if this instance is disposed yet</b>.
+        /// </remarks>
+        /// <exception cref="IOException">The <see cref="WriteTimeout"/> is reach or Attempt to write stream to the disconnected connection</exception>
+        Task WriteAsync(byte[] bytes);
+
         event EventHandler StatusChanged;
         event EventHandler Disconnected;
         event EventHandler Connected;

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -31,6 +31,8 @@ namespace ESCPOS_NET
         private readonly NetworkPrinterSettings _settings;
         private TCPConnection _tcpConnection;
 
+        protected override bool IsConnected => _tcpConnection?.IsConnected??false;
+
         public NetworkPrinter(NetworkPrinterSettings settings) : base(settings.PrinterName)
         {
             _settings = settings;
@@ -48,31 +50,42 @@ namespace ESCPOS_NET
         private void ConnectedEvent(object sender, ClientConnectedEventArgs e)
         {
             Logging.Logger?.LogInformation("[{Function}]:[{PrinterName}] Connected successfully to network printer! Connection String: {ConnectionString}", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName, _settings.ConnectionString);
-            IsConnected = true;
+            // Close previously created reader and writer if any (for handling reconnect after connection lose (in the future))
+            Reader?.Close();
+            Writer?.Close();
+            Reader = new BinaryReader(_tcpConnection.ReadStream);
+            Writer = new BinaryWriter(_tcpConnection.WriteStream);
             InvokeConnect();
         }
         private void DisconnectedEvent(object sender, ClientDisconnectedEventArgs e)
         {
-            IsConnected = false;
             InvokeDisconnect();
             Logging.Logger?.LogWarning("[{Function}]:[{PrinterName}] Network printer connection terminated. Attempting to reconnect. Connection String: {ConnectionString}", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName, _settings.ConnectionString);
             Connect();
         }
-        private void AttemptReconnectInfinitely()
+        private async ValueTask AttemptReconnectInfinitely()
         {
             try
             {
                 //_tcpConnection.ConnectWithRetries(300000);
                 _tcpConnection.ConnectWithRetries(3000);
             }
-            catch (Exception e)
+            catch (TimeoutException)
             {
                 //Logging.Logger?.LogWarning("[{Function}]:[{PrinterName}] Network printer unable to connect after 5 minutes. Attempting to reconnect. Settings: {Settings}", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName, JsonSerializer.Serialize(_settings));
-                Task.Run(async () => { await Task.Delay(250); Connect(); });
+                await Task.Delay(250);
+                CreateTcpConnection();
+                await AttemptReconnectInfinitely();
             }
         }
 
         private void Connect()
+        {
+            CreateTcpConnection();
+            Task.Run(async () => { await AttemptReconnectInfinitely(); });
+        }
+
+        private void CreateTcpConnection()
         {
             if (_tcpConnection != null)
             {
@@ -86,11 +99,6 @@ namespace ESCPOS_NET
             // set events
             _tcpConnection.Connected += ConnectedEvent;
             _tcpConnection.Disconnected += DisconnectedEvent;
-
-            Reader = new BinaryReader(_tcpConnection.ReadStream);
-            Writer = new BinaryWriter(_tcpConnection.WriteStream);
-
-            Task.Run(() => { AttemptReconnectInfinitely(); });
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Printers/SerialPrinter.cs
+++ b/ESCPOS_NET/Printers/SerialPrinter.cs
@@ -8,6 +8,11 @@ namespace ESCPOS_NET
     {
         private readonly SerialPort _serialPort;
 
+        /// <summary>
+        /// Expose to be reused elsewhere as Serial Port will be held open.
+        /// </summary>
+        public SerialPort SerialPort => _serialPort;
+
         public SerialPrinter(string portName, int baudRate)
             : base()
         {


### PR DESCRIPTION
### :rotating_light: Issues found in the current version.
1. The current version when call Write...
      - It swallows all exceptions. 
      - The caller is impossible to know when the bytes are written to the stream. It could be in the next couple of hours when the connection is restored which it may no longer need.
2. It works well only when declaring the printer object as a singleton. Create a printer object multiple times causes the later ones do not really print when calling Write. That is due to the TCP connection does not properly manage to dispose but await for GC to collect the former one(s) so the printer remains to connect to the former connection. The new printer object performs write to the stream that no one listening.
3. WriteLongRunningTask remains running forever even the printer object is disposed because its CancellationTokenSource is never canceled.
4. NetworkPrinter creates infinite new tasks while attempt to connect.
5. Looking at the code of SuperSimpleTcp, calling ConnectWithRetries is a little more expensive than just call Connect. With the fact that less percentage of the NetworkPrinter to fail to connect since the first time, I assume trying to call Connect as the first attempt should give slightly better performance.

### :sparkles: Purpose changes in this PR
1. Introduces the **WriteAsync** function to allow using await or Wait() to explicitly capture the exception if it takes longer than the configurable timeout to connect prior. The legacy Write function remains to use as-is for swallowing exceptions and no need to wait for the connection. Calling WriteAsync without await nor Wait() behaves the same as calling the legacy Write function (this purpose to fix 1 above).
2. Update TCPConnection to implement IDisposable and dispose TCPConnection in NetworkPrinter's dispose function.
3. Replace ConcurrentQueue of writing by marshaling byte array with BlockingCollection and TaskCompleteSource. This made WriteAsync possible and remain legacy behavior with Write or WriteAsync without awaiting yet also enhance speed :racehorse: to the WriteLongRunningTask (compare result by running ConsoleTest + TCPPrintServerTest). This also fixes issue 3 above.
4. Fix issue 4 above.
5. Revise per issue 5 above.
6. Update ConsoleTest to be able to test using singleton printer object or short-lived printer object with a single bool variable switch.
7. Enhance TCPPrintServerTest to support multiple TCP connections. This is for both when the same TCP connection is reconnected or when the TCP connection is closed and then create a new TCP connection.

Sorry to pack many changes :package::package: in a single PR :bow: