### PR TITLE
Fixed unit tests for MICRO QrCode

### DIFF
--- a/ESCPOS_NET.UnitTest/EmittersBased/EPSONTests/BarCode.cs
+++ b/ESCPOS_NET.UnitTest/EmittersBased/EPSONTests/BarCode.cs
@@ -1,4 +1,5 @@
 ﻿using ESCPOS_NET.Emitters;
+using ESCPOS_NET.Utilities;
 using Xunit;
 
 namespace ESCPOS_NET.UnitTest.EmittersBased.EPSONTests
@@ -6,6 +7,7 @@ namespace ESCPOS_NET.UnitTest.EmittersBased.EPSONTests
     public class BarCode
     {
         private const string WEBSITE_STRING = "https://github.com/lukevp/ESC-POS-.NET/";
+        private const string SHORTER_WEBSITE_STRING = "https://github.com/";
 
         [Theory]
         [InlineData(TwoDimensionCodeType.QRCODE_MODEL1, Size2DCode.EXTRA, CorrectionLevel2DCode.PERCENT_15)]
@@ -70,8 +72,23 @@ namespace ESCPOS_NET.UnitTest.EmittersBased.EPSONTests
         [InlineData(TwoDimensionCodeType.QRCODE_MICRO, Size2DCode.TINY, CorrectionLevel2DCode.PERCENT_7)]
         public void PrintQRCode_Success(TwoDimensionCodeType codeType, Size2DCode size2DCode, CorrectionLevel2DCode correctionLevel2DCode)
         {
-            var result = new byte[] { 29, 40, 107, 4, 0, 49, 65, (byte)codeType, 0, 29, 40, 107, 3, 0, 49, 67, (byte)size2DCode, 29, 40, 107, 3, 0, 49, 69, (byte)correctionLevel2DCode, 29, 40, 107, 42, 0, 49, 80, 48, 104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 108, 117, 107, 101, 118, 112, 47, 69, 83, 67, 45, 80, 79, 83, 45, 46, 78, 69, 84, 47, 29, 40, 107, 3, 0, 49, 81, 48 };
-            Assert.Equal(result, new EPSON().Print2DCode(codeType, WEBSITE_STRING, size2DCode, correctionLevel2DCode));
+            string data = codeType == TwoDimensionCodeType.QRCODE_MICRO ? SHORTER_WEBSITE_STRING : WEBSITE_STRING;
+            var begining = new byte[] { 29, 40, 107, 4, 0, 49, 65, (byte)codeType, 0, 29, 40, 107, 3, 0, 49, 67, (byte)size2DCode, 29, 40, 107, 3, 0, 49, 69, (byte)correctionLevel2DCode, 29, 40, 107, (byte)(data.Length + 3), 0, 49, 80, 48, 104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47 };
+            var ending = new byte[] { 29, 40, 107, 3, 0, 49, 81, 48 };
+            
+            byte[] result;
+            if (codeType == TwoDimensionCodeType.QRCODE_MICRO)
+            {
+                result = ByteSplicer.Combine(begining, ending);
+            }
+            else
+            {
+                var longerStr = new byte[] { 108, 117, 107, 101, 118, 112, 47, 69, 83, 67, 45, 80, 79, 83, 45, 46, 78, 69, 84, 47, };
+                result = ByteSplicer.Combine(begining, longerStr, ending);
+            }
+            
+            Assert.Equal(result, new EPSON().Print2DCode(codeType, data, size2DCode, correctionLevel2DCode));
         }
     }
 }
+

--- a/ESCPOS_NET.UnitTest/GlobalTests/Barcode.cs
+++ b/ESCPOS_NET.UnitTest/GlobalTests/Barcode.cs
@@ -8,6 +8,7 @@ namespace ESCPOS_NET.UnitTest.GlobalTests
     public class Barcode
     {
         private const string WEBSITE_STRING = "https://github.com/lukevp/ESC-POS-.NET/";
+        private const string SHORTER_WEBSITE_STRING = "https://github.com/";
 
         [Theory]
         [InlineData("EPSON", TwoDimensionCodeType.QRCODE_MODEL1)]
@@ -21,7 +22,10 @@ namespace ESCPOS_NET.UnitTest.GlobalTests
 
             byte[] bytes;
             if (codeType is TwoDimensionCodeType codeTypeValue)
-                bytes = e.PrintQRCode(WEBSITE_STRING, codeTypeValue);
+            {
+                string data = codeTypeValue == TwoDimensionCodeType.QRCODE_MICRO ? SHORTER_WEBSITE_STRING : WEBSITE_STRING;
+                bytes = e.PrintQRCode(data, codeTypeValue);
+            }
             else
                 bytes = e.PrintQRCode(WEBSITE_STRING);
 


### PR DESCRIPTION
We changed validation regarding data length for QRCode model MICRO, but never realized that it was failing the unit tests because the string that used string was longer than the max length.