### PR TITLE
Creation of new Fluent API through DirectPrinter class

### DIFF
--- a/ESCPOS_NET.UnitTest/GlobalTests/DirectPrinterTests.cs
+++ b/ESCPOS_NET.UnitTest/GlobalTests/DirectPrinterTests.cs
@@ -1,0 +1,61 @@
+﻿using ESCPOS_NET.Emitters;
+using ESCPOS_NET.Printers;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace ESCPOS_NET.UnitTest.GlobalTests
+{
+    public class DirectPrinterTests
+    {
+        // When new emitters exist, add their class name to new InlineData
+        [InlineData("EPSON")]
+        [Theory]
+        public void VerifyInternalBufferIsUpdated(string emitter)
+        {
+            var type = Assembly.LoadFrom("ESCPOS_NET").GetType($"ESCPOS_NET.Emitters.{emitter}", true);
+            ICommandEmitter e = (ICommandEmitter)Activator.CreateInstance(type);
+            
+            //Use Print Command so Buffer is updated internally
+            var directPrinter = new DirectPrinter(e, null);
+            directPrinter.Print("ABC").Print("DEF");
+
+            byte[] result = { 65, 66, 67, 68, 69, 70 };
+            Assert.Equal(result, directPrinter.Buffer);
+        }
+
+        [Theory]
+        [InlineData("EPSON")]
+        public void VerifyInternalBufferIsCleared(string emitter)
+        {
+            var type = Assembly.LoadFrom("ESCPOS_NET").GetType($"ESCPOS_NET.Emitters.{emitter}", true);
+            ICommandEmitter e = (ICommandEmitter)Activator.CreateInstance(type);
+
+            //Use Print Command so Buffer is updated internally
+            var directPrinter = new DirectPrinter(e, null);
+            directPrinter.Print("ABC").Print("DEF");
+
+            //Clear Buffer and adds different bytes
+            directPrinter.ClearAll();
+            directPrinter.Print("GHI").Print("JKL");
+
+            byte[] result = { 71, 72, 73, 74, 75, 76 };
+            Assert.Equal(result, directPrinter.Buffer);            
+        }
+
+        [Theory]
+        [InlineData("EPSON")]
+        public void VerifyQRCodeIsSameAsCallingFromEmitter(string emitter)
+        {
+            var type = Assembly.LoadFrom("ESCPOS_NET").GetType($"ESCPOS_NET.Emitters.{emitter}", true);
+            ICommandEmitter e = (ICommandEmitter)Activator.CreateInstance(type);
+
+            //Use Print Command so Buffer is updated internally
+            var directPrinter = new DirectPrinter(e, null);
+            directPrinter.PrintQRCode("ABC");
+
+            byte[] expected = e.PrintQRCode("ABC");
+            Assert.Equal(expected, directPrinter.Buffer);
+        }
+    }
+}

--- a/ESCPOS_NET/ByteSplicer.cs
+++ b/ESCPOS_NET/ByteSplicer.cs
@@ -7,7 +7,9 @@
             ByteArrayBuilder builder = new ByteArrayBuilder();
             foreach (var byteArray in byteArrays)
             {
-                builder.Append(byteArray);
+                // For easier usage, ignore null byte arrays
+                if (byteArray != null)
+                    builder.Append(byteArray);
             }
             return builder.ToArray();
         }

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -75,6 +75,7 @@ namespace ESCPOS_NET.Emitters
         /* Barcode Commands */
         byte[] PrintBarcode(BarcodeType type, string barcode, BarcodeCode code = BarcodeCode.CODE_B);
 
+        /* 2D-Code Commands */
         byte[] PrintQRCode(string data, TwoDimensionCodeType type = TwoDimensionCodeType.QRCODE_MODEL2, Size2DCode size = Size2DCode.NORMAL, CorrectionLevel2DCode correction = CorrectionLevel2DCode.PERCENT_7);
 
         byte[] Print2DCode(TwoDimensionCodeType type, string data, Size2DCode size = Size2DCode.NORMAL, CorrectionLevel2DCode correction = CorrectionLevel2DCode.PERCENT_7);
@@ -86,7 +87,5 @@ namespace ESCPOS_NET.Emitters
         byte[] SetBarLabelPosition(BarLabelPrintPosition position);
 
         byte[] SetBarLabelFontB(bool fontB);
-
-        /* 2D-Code Commands */
     }
 }

--- a/ESCPOS_NET/Printers/DirectPrinter.cs
+++ b/ESCPOS_NET/Printers/DirectPrinter.cs
@@ -1,0 +1,262 @@
+﻿using ESCPOS_NET.Emitters;
+using ESCPOS_NET.Utilities;
+
+namespace ESCPOS_NET.Printers
+{   
+    public class DirectPrinter
+    {
+        private ICommandEmitter Emitter { get; }
+        private IPrinter Printer { get; }
+        public byte[] Buffer { get; private set; }
+
+        public DirectPrinter(ICommandEmitter emitter, IPrinter printer)
+        {
+            this.Emitter = emitter;
+            this.Printer = printer;
+        }
+
+        public DirectPrinter Send()
+        {
+            this.Printer.Write(this.Buffer);
+            ClearAll();
+            return this;
+        }
+
+        public DirectPrinter Print(string str)
+        {
+            UpdateBuffer(this.Emitter.Print(str));
+            return this;
+        }
+
+        public DirectPrinter Initialize()
+        {
+            UpdateBuffer(this.Emitter.Initialize());
+            return this;
+        }
+
+        public DirectPrinter PrintLine(string line = null)
+        {
+            UpdateBuffer(this.Emitter.PrintLine(line));
+            return this;
+        }
+
+        public DirectPrinter FeedLines(int lineCount)
+        {
+            UpdateBuffer(this.Emitter.FeedLines(lineCount));
+            return this;
+        }
+
+        public DirectPrinter FeedLinesReverse(int lineCount)
+        {
+            UpdateBuffer(this.Emitter.FeedLinesReverse(lineCount));
+            return this;
+        }
+
+        public DirectPrinter FeedDots(int dotCount)
+        {
+            UpdateBuffer(this.Emitter.FeedDots(dotCount));
+            return this;
+        }
+
+        public DirectPrinter ResetLineSpacing()
+        {
+            UpdateBuffer(this.Emitter.ResetLineSpacing());
+            return this;
+        }
+
+        public DirectPrinter SetLineSpacingInDots(int dots)
+        {
+            UpdateBuffer(this.Emitter.SetLineSpacingInDots(dots));
+            return this;
+        }
+
+        public DirectPrinter Enable()
+        {
+            UpdateBuffer(this.Emitter.Enable());
+            return this;
+        }
+
+        public DirectPrinter Disable()
+        {
+            UpdateBuffer(this.Emitter.Disable());
+            return this;
+        }
+
+        public DirectPrinter CashDrawerOpenPin2(int pulseOnTimeMs = 120, int pulseOffTimeMs = 240)
+        {
+            UpdateBuffer(this.Emitter.CashDrawerOpenPin2(pulseOnTimeMs, pulseOffTimeMs));
+            return this;
+        }
+
+        public DirectPrinter CashDrawerOpenPin5(int pulseOnTimeMs = 120, int pulseOffTimeMs = 240)
+        {
+            UpdateBuffer(this.Emitter.CashDrawerOpenPin5(pulseOnTimeMs, pulseOffTimeMs));
+            return this;
+        }
+
+        public DirectPrinter SetStyles(PrintStyle style)
+        {
+            UpdateBuffer(this.Emitter.SetStyles(style));
+            return this;
+        }
+
+        public DirectPrinter LeftAlign()
+        {
+            UpdateBuffer(this.Emitter.LeftAlign());
+            return this;
+        }
+
+        public DirectPrinter RightAlign()
+        {
+            UpdateBuffer(this.Emitter.RightAlign());
+            return this;
+        }
+
+        public DirectPrinter CenterAlign()
+        {
+            UpdateBuffer(this.Emitter.CenterAlign());
+            return this;
+        }
+
+        public DirectPrinter ReverseMode(bool activate)
+        {
+            UpdateBuffer(this.Emitter.ReverseMode(activate));
+            return this;
+        }
+
+        public DirectPrinter RightCharacterSpacing(int spaceCount)
+        {
+            UpdateBuffer(this.Emitter.RightCharacterSpacing(spaceCount));
+            return this;
+        }
+
+        public DirectPrinter UpsideDownMode(bool activate)
+        {
+            UpdateBuffer(this.Emitter.UpsideDownMode(activate));
+            return this;
+        }
+
+        public DirectPrinter CodePage(CodePage codePage)
+        {
+            UpdateBuffer(this.Emitter.CodePage(codePage));
+            return this;
+        }
+
+        public DirectPrinter Color(Color color)
+        {
+            UpdateBuffer(this.Emitter.Color(color));
+            return this;
+        }
+
+        public DirectPrinter FullCut()
+        {
+            UpdateBuffer(this.Emitter.FullCut());
+            return this;
+        }
+
+        public DirectPrinter PartialCut()
+        {
+            UpdateBuffer(this.Emitter.PartialCut());
+            return this;
+        }
+
+        public DirectPrinter FullCutAfterFeed(int lineCount)
+        {
+            UpdateBuffer(this.Emitter.FullCutAfterFeed(lineCount));
+            return this;
+        }
+
+        public DirectPrinter PartialCutAfterFeed(int lineCount)
+        {
+            UpdateBuffer(this.Emitter.PartialCutAfterFeed(lineCount));
+            return this;
+        }
+
+        public DirectPrinter SetImageDensity(bool isHiDPI)
+        {
+            UpdateBuffer(this.Emitter.SetImageDensity(isHiDPI));
+            return this;
+        }
+
+        public DirectPrinter BufferImage(byte[] image, int maxWidth, bool isLegacy = false, int color = 1)
+        {
+            UpdateBuffer(this.Emitter.BufferImage(image, maxWidth, isLegacy, color));
+            return this;
+        }
+
+        public DirectPrinter WriteImageFromBuffer()
+        {
+            UpdateBuffer(this.Emitter.WriteImageFromBuffer());
+            return this;
+        }
+
+        public DirectPrinter PrintImage(byte[] image, bool isHiDPI, bool isLegacy = false, int maxWidth = -1, int color = 1)
+        {
+            UpdateBuffer(this.Emitter.PrintImage(image, isHiDPI, isLegacy, maxWidth, color));
+            return this;
+        }
+
+        public DirectPrinter EnableAutomaticStatusBack()
+        {
+            UpdateBuffer(this.Emitter.EnableAutomaticStatusBack());
+            return this;
+        }
+
+        public DirectPrinter EnableAutomaticInkStatusBack()
+        {
+            UpdateBuffer(this.Emitter.EnableAutomaticInkStatusBack());
+            return this;
+        }
+
+        public DirectPrinter PrintBarcode(BarcodeType type, string barcode, BarcodeCode code = BarcodeCode.CODE_B)
+        {
+            UpdateBuffer(this.Emitter.PrintBarcode(type, barcode, code));
+            return this;
+        }
+
+        public DirectPrinter PrintQRCode(string data, TwoDimensionCodeType type = TwoDimensionCodeType.QRCODE_MODEL2, Size2DCode size = Size2DCode.NORMAL, CorrectionLevel2DCode correction = CorrectionLevel2DCode.PERCENT_7)
+        {
+            UpdateBuffer(this.Emitter.PrintQRCode(data, type, size, correction));
+            return this;
+        }
+
+        public DirectPrinter Print2DCode(TwoDimensionCodeType type, string data, Size2DCode size = Size2DCode.NORMAL, CorrectionLevel2DCode correction = CorrectionLevel2DCode.PERCENT_7)
+        {
+            UpdateBuffer(this.Emitter.Print2DCode(type, data, size, correction));
+            return this;
+        }
+
+        public DirectPrinter SetBarcodeHeightInDots(int height)
+        {
+            UpdateBuffer(this.Emitter.SetBarcodeHeightInDots(height));
+            return this;
+        }
+
+        public DirectPrinter SetBarWidth(BarWidth width)
+        {
+            UpdateBuffer(this.Emitter.SetBarWidth(width));
+            return this;
+        }
+
+        public DirectPrinter SetBarLabelPosition(BarLabelPrintPosition position)
+        {
+            UpdateBuffer(this.Emitter.SetBarLabelPosition(position));
+            return this;
+        }
+
+        public DirectPrinter SetBarLabelFontB(bool fontB)
+        {
+            UpdateBuffer(this.Emitter.SetBarLabelFontB(fontB));
+            return this;
+        }
+
+        public DirectPrinter ClearAll()
+        {
+            this.Buffer = null;
+            return this;
+        }
+
+        private void UpdateBuffer(byte[] newBytes)
+            => this.Buffer = ByteSplicer.Combine(Buffer, newBytes);
+    }
+}


### PR DESCRIPTION
Fixes #82 

@lukevp, I finally got back to this. 

The end result is exactly what you suggested in #82 

```cs
var DirectPrinter = new DirectPrinter(emitter, printer);
DirectPrinter.CenterAlign()
             .Print("Centered Text")
             .LeftAlign()
             .Print("Left Aligned Text")
             .Send();
```

There's an internal buffer that holds the byte arrays being added. Once the `Send` method is called, the buffer is sent to `printer.Write` and the buffer is cleared out. This means that the code below will send "ABC" to the printer and then send only "DEF" to the printer shortly after

```cs
var DirectPrinter = new DirectPrinter(emitter, printer);
DirectPrinter.Print("ABC").Send()
             .Print("DEF").Send();
```



Sorry I got lazy on the unit tests, but following the same principle we should have at least 1 test per command, to guarantee that calling a command through the emitter produces the exact same result as calling it through the DirectPrinter class. Right now that's easily seen, but in a future with multiple emitters and refactoring, unit tests would raise the red flag if something not expected happened. 

Talking about raising flags, have you considered an auto pipeline? So you can have a build and tests check every merge/commit the repo gets on the master branch? You usually put a badge with the build status on the README.md 

For example this one that I'm using on my repo. It uses Azure DevOps Pipelines:
![image](https://user-images.githubusercontent.com/10572656/135706376-291e3042-879a-48dc-8159-56a35fa877c2.png)


