### PR TITLE
Clean up object disposal and shutdown long running tasks.

### DIFF
--- a/ESCPOS_NET.ConsoleTest/Program.cs
+++ b/ESCPOS_NET.ConsoleTest/Program.cs
@@ -92,6 +92,8 @@ namespace ESCPOS_NET.ConsoleTest
                 printer = new NetworkPrinter(settings: new NetworkPrinterSettings() { ConnectionString = $"{ip}:{networkPort}" });
             }
 
+            printer.Connect();
+
             bool monitor = false;
             Thread.Sleep(500);
             Console.Write("Turn on Live Status Back Monitoring? (y/n): ");

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/CharacterCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/CharacterCommands.cs
@@ -13,6 +13,12 @@ namespace ESCPOS_NET.Emitters
 
         public virtual byte[] RightAlign() => new byte[] { Cmd.ESC, Chars.Alignment, (byte)Align.Right };
 
+        public virtual byte[] LeftAlignAlt() => new byte[] { Cmd.ESC, Chars.Alignment, (byte)Align.LeftAlt };
+
+        public virtual byte[] CenterAlignAlt() => new byte[] { Cmd.ESC, Chars.Alignment, (byte)Align.CenterAlt };
+
+        public virtual byte[] RightAlignAlt() => new byte[] { Cmd.ESC, Chars.Alignment, (byte)Align.RightAlt };
+
         public virtual byte[] RightCharacterSpacing(int spaceCount) => new byte[] { Cmd.ESC, Chars.RightCharacterSpacing, (byte)spaceCount };
 
         public virtual byte[] CodePage(CodePage codePage) => new byte[] { Cmd.ESC, Chars.CodePage, (byte)codePage };

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/OperationalCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/OperationalCommands.cs
@@ -10,5 +10,7 @@ namespace ESCPOS_NET.Emitters
         public virtual byte[] Enable() => new byte[] { Cmd.ESC, Ops.EnableDisable, 1 };
 
         public virtual byte[] Disable() => new byte[] { Cmd.ESC, Ops.EnableDisable, 0 };
+
+        public virtual byte[] StandardMode() => new byte[] { Cmd.ESC, Ops.StandardMode };
     }
 }

--- a/ESCPOS_NET/Emitters/BaseCommandValues/Ops.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandValues/Ops.cs
@@ -6,5 +6,6 @@
         public static readonly byte EnableDisable = 0x3D;
         public static readonly byte PaperCut = 0x56;
         public static readonly byte CashDrawerPulse = 0x70;
+        public static readonly byte StandardMode = 0x1B;
     }
 }

--- a/ESCPOS_NET/Emitters/Enums/Align.cs
+++ b/ESCPOS_NET/Emitters/Enums/Align.cs
@@ -6,5 +6,8 @@
         Left   = 0,
         Center = 1,
         Right  = 2,
+        LeftAlt = 48,
+        CenterAlt = 49,
+        RightAlt = 50
     }
 }

--- a/ESCPOS_NET/Emitters/Enums/PrintStyle.cs
+++ b/ESCPOS_NET/Emitters/Enums/PrintStyle.cs
@@ -8,9 +8,12 @@ namespace ESCPOS_NET.Emitters
     {
         None         = 0,
         FontB        = 1,
+        Proportional = 1 << 1,
+        Condensed    = 1 << 2,
         Bold         = 1 << 3,
         DoubleHeight = 1 << 4,
         DoubleWidth  = 1 << 5,
+        Italic      = 1 << 6,
         Underline    = 1 << 7,
     }
 }

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -49,7 +49,6 @@ namespace ESCPOS_NET
         protected BasePrinter()
         {
             PrinterName = Guid.NewGuid().ToString();
-            Init();
         }
         protected BasePrinter(string printerName)
         {
@@ -58,9 +57,9 @@ namespace ESCPOS_NET
                 printerName = Guid.NewGuid().ToString();
             }
             PrinterName = printerName;
-            Init();
         }
-        private void Init()
+
+        public virtual void Connect()
         {
             _readCancellationTokenSource = new CancellationTokenSource();
             _writeCancellationTokenSource = new CancellationTokenSource();

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -61,6 +61,9 @@ namespace ESCPOS_NET
 
         public virtual void Connect()
         {
+            if (Reader == null || Writer == null)
+                throw new Exception("Reader and Writer were null, call base.Connect after establishing them in the child printer driver.");
+
             _readCancellationTokenSource = new CancellationTokenSource();
             _writeCancellationTokenSource = new CancellationTokenSource();
             Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Initializing Task Threads...", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -155,11 +155,15 @@ namespace ESCPOS_NET
                 {
                     // Sometimes the serial port lib will throw an exception and read past the end of the queue if a
                     // status changes while data is being written.  We just ignore these bytes.
-                    var b = Reader.BaseStream.ReadByte();
-                    if (b >= 0 && b <= 255)
+                    byte[] buffer = new byte[1];
+                    var count = await Reader.BaseStream.ReadAsync(buffer, 0, 1, _readCancellationTokenSource.Token);
+                    if (count > 0)
                     {
-                        ReadBuffer.Enqueue((byte)b);
-                        DataAvailable();
+                        if (buffer[0] >= 0 && buffer[0] <= 255)
+                        {
+                            ReadBuffer.Enqueue((byte)buffer[0]);
+                            DataAvailable();
+                        }
                     }
                 }
 

--- a/ESCPOS_NET/Printers/FilePrinter.cs
+++ b/ESCPOS_NET/Printers/FilePrinter.cs
@@ -4,11 +4,19 @@ namespace ESCPOS_NET
 {
     public class FilePrinter : BasePrinter
     {
-        private readonly FileStream _file;
+        private FileStream _file;
+        private bool createIfNotExists;
+        private string filePath;
 
         // TODO: default values to their default values in ctor.
         public FilePrinter(string filePath, bool createIfNotExists = false)
             : base()
+        {
+            this.createIfNotExists = createIfNotExists;
+            this.filePath = filePath;
+        }
+
+        public override void Connect()
         {
             if (createIfNotExists)
             {
@@ -20,6 +28,8 @@ namespace ESCPOS_NET
             }
             Writer = new BinaryWriter(_file);
             Reader = new BinaryReader(_file);
+
+            base.Connect();
         }
 
         ~FilePrinter()

--- a/ESCPOS_NET/Printers/FilePrinter.cs
+++ b/ESCPOS_NET/Printers/FilePrinter.cs
@@ -16,7 +16,7 @@ namespace ESCPOS_NET
             this.filePath = filePath;
         }
 
-        public override void Connect()
+        public override void Connect(bool reconnecting = false)
         {
             if (createIfNotExists)
             {
@@ -29,7 +29,7 @@ namespace ESCPOS_NET
             Writer = new BinaryWriter(_file);
             Reader = new BinaryReader(_file);
 
-            base.Connect();
+            base.Connect(reconnecting);
         }
 
         ~FilePrinter()

--- a/ESCPOS_NET/Printers/FilePrinter.cs
+++ b/ESCPOS_NET/Printers/FilePrinter.cs
@@ -26,10 +26,23 @@ namespace ESCPOS_NET
             {
                 _file = File.Open(filePath, FileMode.Open);
             }
-            Writer = new BinaryWriter(_file);
-            Reader = new BinaryReader(_file);
 
             base.Connect(reconnecting);
+        }
+
+        protected override int ReadBytesUnderlying(byte[] buffer, int offset, int bufferSize)
+        {
+            return _file.Read(buffer, offset, bufferSize);
+        }
+        
+        protected override void WriteBytesUnderlying(byte[] buffer, int offset, int count)
+        {
+            _file.Write(buffer, offset, count);
+        }
+
+        protected override void FlushUnderlying()
+        {
+            _file.Flush();
         }
 
         ~FilePrinter()

--- a/ESCPOS_NET/Printers/MemoryPrinter.cs
+++ b/ESCPOS_NET/Printers/MemoryPrinter.cs
@@ -11,7 +11,6 @@ namespace ESCPOS_NET
             : base()
         {
             _ms = new MemoryStream();
-            Writer = new BinaryWriter(_ms);
         }
 
         ~MemoryPrinter()
@@ -22,6 +21,21 @@ namespace ESCPOS_NET
         public byte[] GetAllData()
         {
             return _ms.ToArray();
+        }
+
+        protected override int ReadBytesUnderlying(byte[] buffer, int offset, int bufferSize)
+        {
+            return 0;
+        }
+
+        protected override void WriteBytesUnderlying(byte[] buffer, int offset, int count)
+        {
+            _ms.Write(buffer, offset, count);
+        }
+
+        protected override void FlushUnderlying()
+        {
+            _ms.Flush();
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -68,12 +68,24 @@ namespace ESCPOS_NET
             _tcpConnection.Connected += ConnectedEvent;
             _tcpConnection.Disconnected += DisconnectedEvent;
 
-            Reader = new BinaryReader(_tcpConnection.ReadStream);
-            Writer = new BinaryWriter(_tcpConnection.WriteStream);
-
             _tcpConnection.ConnectWithRetries(3000);
 
             base.Connect(reconnecting);
+        }
+
+        protected override void WriteBytesUnderlying(byte[] buffer, int offset, int count)
+        {
+            _tcpConnection.WriteStream?.Write(buffer, offset, count);
+        }
+
+        protected override int ReadBytesUnderlying(byte[] buffer, int offset, int bufferSize)
+        {
+            return _tcpConnection.ReadStream?.Read(buffer, offset, bufferSize) ?? 0;
+        }
+
+        protected override void FlushUnderlying()
+        {
+            _tcpConnection.WriteStream?.Flush();
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -57,8 +57,9 @@ namespace ESCPOS_NET
             Connect();
         }
         
-        private void Connect()
+        public override void Connect()
         {
+
             OverridableDispose();
 
             // instantiate
@@ -72,6 +73,8 @@ namespace ESCPOS_NET
             Writer = new BinaryWriter(_tcpConnection.WriteStream);
 
             _tcpConnection.ConnectWithRetries(3000);
+
+            base.Connect();
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -39,7 +39,6 @@ namespace ESCPOS_NET
             {
                 Disconnected += settings.DisconnectedHandler;
             }
-            Connect();
         }
 
         private void ConnectedEvent(object sender, ClientConnectedEventArgs e)

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -54,10 +54,10 @@ namespace ESCPOS_NET
             IsConnected = false;
             InvokeDisconnect();
             Logging.Logger?.LogWarning("[{Function}]:[{PrinterName}] Network printer connection terminated. Attempting to reconnect. Connection String: {ConnectionString}", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName, _settings.ConnectionString);
-            Connect();
+            Connect(true);
         }
-        
-        public override void Connect()
+
+        public override void Connect(bool reconnecting = false)
         {
 
             OverridableDispose();
@@ -74,7 +74,7 @@ namespace ESCPOS_NET
 
             _tcpConnection.ConnectWithRetries(3000);
 
-            base.Connect();
+            base.Connect(reconnecting);
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Printers/NetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/NetworkPrinter.cs
@@ -59,12 +59,7 @@ namespace ESCPOS_NET
         
         private void Connect()
         {
-            if (_tcpConnection != null)
-            {
-                _tcpConnection.Connected -= ConnectedEvent;
-                _tcpConnection.Disconnected -= DisconnectedEvent;
-                _tcpConnection.Dispose();
-            }
+            OverridableDispose();
 
             // instantiate
             _tcpConnection = new TCPConnection(_settings.ConnectionString);
@@ -81,8 +76,13 @@ namespace ESCPOS_NET
 
         protected override void OverridableDispose()
         {
-            _tcpConnection?.Dispose();
-            _tcpConnection = null;
+            if (_tcpConnection != null)
+            {
+                _tcpConnection.Connected -= ConnectedEvent;
+                _tcpConnection.Disconnected -= DisconnectedEvent;
+                _tcpConnection?.Dispose();
+                _tcpConnection = null;
+            }
         }
     }
 }

--- a/ESCPOS_NET/Printers/SerialPrinter.cs
+++ b/ESCPOS_NET/Printers/SerialPrinter.cs
@@ -6,22 +6,35 @@ namespace ESCPOS_NET
 {
     public class SerialPrinter : BasePrinter
     {
-        private readonly SerialPort _serialPort;
+        private readonly string portName;
+        private readonly int baudRate;
+        private SerialPort _serialPort;
 
         public SerialPrinter(string portName, int baudRate)
             : base()
+        {
+            this.portName = portName;
+            this.baudRate = baudRate;
+        }
+
+        public override void Connect()
         {
             _serialPort = new SerialPort(portName, baudRate);
             _serialPort.Open();
             Writer = new BinaryWriter(_serialPort.BaseStream);
             Reader = new BinaryReader(_serialPort.BaseStream);
+
+            base.Connect();
         }
 
         protected override void OverridableDispose()
         {
-            _serialPort?.Close();
-            _serialPort?.Dispose();
-            Task.Delay(250).Wait(); // Based on MSDN Documentation, should sleep after calling Close or some functionality will not be determinant.
+            if (_serialPort != null)
+            {
+                _serialPort?.Close();
+                _serialPort?.Dispose();
+                Task.Delay(250).Wait(); // Based on MSDN Documentation, should sleep after calling Close or some functionality will not be determinant.
+            }
         }
     }
 }

--- a/ESCPOS_NET/Printers/SerialPrinter.cs
+++ b/ESCPOS_NET/Printers/SerialPrinter.cs
@@ -17,14 +17,14 @@ namespace ESCPOS_NET
             this.baudRate = baudRate;
         }
 
-        public override void Connect()
+        public override void Connect(bool reconnecting = false)
         {
             _serialPort = new SerialPort(portName, baudRate);
             _serialPort.Open();
             Writer = new BinaryWriter(_serialPort.BaseStream);
             Reader = new BinaryReader(_serialPort.BaseStream);
 
-            base.Connect();
+            base.Connect(reconnecting);
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Printers/SerialPrinter.cs
+++ b/ESCPOS_NET/Printers/SerialPrinter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.IO.Ports;
 using System.Threading.Tasks;
@@ -21,10 +22,24 @@ namespace ESCPOS_NET
         {
             _serialPort = new SerialPort(portName, baudRate);
             _serialPort.Open();
-            Writer = new BinaryWriter(_serialPort.BaseStream);
-            Reader = new BinaryReader(_serialPort.BaseStream);
 
             base.Connect(reconnecting);
+        }
+
+        protected override int ReadBytesUnderlying(byte[] buffer, int offset, int bufferSize)
+        {
+            if (this._serialPort.BytesToRead == 0) return 0;
+            return this._serialPort.Read(buffer, 0, Math.Min(bufferSize, this._serialPort.BytesToRead));
+        }
+
+        protected override void WriteBytesUnderlying(byte[] buffer, int offset, int count)
+        {
+            this._serialPort.Write(buffer, 0, count);
+        }
+
+        protected override void FlushUnderlying()
+        {
+            // noop
         }
 
         protected override void OverridableDispose()

--- a/ESCPOS_NET/Utils/EchoStream.cs
+++ b/ESCPOS_NET/Utils/EchoStream.cs
@@ -81,16 +81,15 @@ namespace ESCPOS_NET.Utils
         // we override the xxxxAsync functions because the default base class shares state between ReadAsync and WriteAsync, which causes a hang if both are called at once
         public new Task WriteAsync(byte[] buffer, int offset, int count)
         {
-            return Task.Run(() => Write(buffer, offset, count));
+            Write(buffer, offset, count);
+
+            return Task.CompletedTask;
         }
 
         // we override the xxxxAsync functions because the default base class shares state between ReadAsync and WriteAsync, which causes a hang if both are called at once
         public new Task<int> ReadAsync(byte[] buffer, int offset, int count)
         {
-            return Task.Run(() =>
-            {
-                return Read(buffer, offset, count);
-            });
+            return Task.FromResult(Read(buffer, offset, count));
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ var printer = new SerialPrinter(portName: "COM5", baudRate: 115200);
 
 // Linux output to USB / Serial file
 var printer = new FilePrinter(filePath: "/dev/usb/lp0");
+
+printer.Connect();
 ```
 ## Step 1a (optional): Monitor for Events - out of paper, cover open...
 ```csharp


### PR DESCRIPTION
Hi, 

This PR makes changes to the base printer object, and the serial and network variants, and to the Esc-Pos protocol.
We have been integrating this on dotnet core across multiple platforms, and had a few challenges.

Base Printer

- Printer types did not dispose consistently for device testing purposes, mostly because the long running threads did not shut down totally.  In the case of the serial printer, the read thread was being blocked by the serialport.read call.
- Removed the binary reader and writer objects and instead move reading and writing down to the printer object itself, which allows the serial printer version to only read if there are bytes available.
- NetworkPrinter was executing a thread that would continually try to reconnect even if the printer connected to was no longer used, which stopped it from being disposed.

EscPos protocol.

- There are alternate versions of the alignment commands depending upon the version of the printer you have.

Thanks for your component, it works with Epson printers nicely.
Adrian