### PR TITLE
Add support for Samba-based network printing

### DIFF
--- a/ESCPOS_NET.ConsoleTest/Program.cs
+++ b/ESCPOS_NET.ConsoleTest/Program.cs
@@ -31,12 +31,14 @@ namespace ESCPOS_NET.ConsoleTest
 
             Console.WriteLine("1 ) Test Serial Port");
             Console.WriteLine("2 ) Test Network Printer");
+            Console.WriteLine("3 ) Test Samba-Shared Printer");
             Console.Write("Choice: ");
             string comPort = "";
             string ip;
             string networkPort;
+            string smbPath;
             response = Console.ReadLine();
-            var valid = new List<string> { "1", "2" };
+            var valid = new List<string> { "1", "2", "3" };
             if (!valid.Contains(response))
             {
                 response = "1";
@@ -91,14 +93,24 @@ namespace ESCPOS_NET.ConsoleTest
                 }
                 printer = new NetworkPrinter(settings: new NetworkPrinterSettings() { ConnectionString = $"{ip}:{networkPort}" });
             }
+            else if (choice == 3)
+            {
+                Console.Write(@"SMB Share Name (eg. \\computer\printer): ");
+                smbPath = Console.ReadLine();
+
+                printer = new SambaPrinter(tempFileBasePath: @"C:\Temp", filePath: smbPath);
+            }
 
             bool monitor = false;
             Thread.Sleep(500);
-            Console.Write("Turn on Live Status Back Monitoring? (y/n): ");
-            response = Console.ReadLine().Trim().ToLowerInvariant();
-            if (response.Length >= 1 && response[0] == 'y')
+            if (choice != 3) // SMB printers do not support reads so status back will not work.
             {
-                monitor = true;
+                Console.Write("Turn on Live Status Back Monitoring? (y/n): ");
+                response = Console.ReadLine().Trim().ToLowerInvariant();
+                if (response.Length >= 1 && response[0] == 'y')
+                {
+                    monitor = true;
+                }
             }
 
             e = new EPSON();

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -220,7 +220,7 @@ namespace ESCPOS_NET
             }
         }
 
-        protected virtual void Flush(object sender, ElapsedEventArgs e)
+        public virtual void Flush(object sender, ElapsedEventArgs e)
         {
             try
             {

--- a/ESCPOS_NET/Printers/SambaPrinter.cs
+++ b/ESCPOS_NET/Printers/SambaPrinter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Timers;
+
+namespace ESCPOS_NET
+{
+    public class SambaPrinter : BasePrinter
+    {
+        private string _filePath;
+        private string _tempFileBasePath;
+        private string _tempFilePath;
+        private MemoryStream _stream;
+
+        public SambaPrinter(string tempFileBasePath, string filePath) : base()
+        {
+            _tempFileBasePath = tempFileBasePath;
+            if (!Directory.Exists(_tempFileBasePath))
+            {
+                Directory.CreateDirectory(_tempFileBasePath);
+            }
+            _stream = new MemoryStream();
+            Writer = new BinaryWriter(new MemoryStream());
+            _filePath = filePath;
+        }
+
+        public override void Flush(object sender, ElapsedEventArgs e)
+        {
+            if (BytesWrittenSinceLastFlush > 0)
+            {
+                var bytes = _stream.ToArray();
+                _stream = new MemoryStream();
+                Writer = new BinaryWriter(_stream);
+
+                _tempFilePath = Path.Combine(_tempFileBasePath, $"{Guid.NewGuid()}.bin");
+                File.WriteAllBytes(_tempFilePath, bytes);
+                File.Copy(_tempFilePath, _filePath);
+                File.Delete(_tempFilePath);
+
+            }
+            BytesWrittenSinceLastFlush = 0;
+        }
+    }
+}


### PR DESCRIPTION
This adds support for printing via Samba-shared printers, along with an
additional option for the ConsoleTest example. Opening up
`BasePrinter`'s `Flush` method also allows for other extensions too.

This is @lukevp's prior work, fixed to allow it to apply cleanly.

https://github.com/lukevp/ESC-POS-.NET/commit/006bff2d63c21e13bc08b8ad9d6b88d008595ccc

Closes #47