### PR TITLE
Add a command for printing rasterized text

### DIFF
--- a/ESCPOS_NET.UnitTest/EmittersBased/EPSONTests/ImageCommandsTests.cs
+++ b/ESCPOS_NET.UnitTest/EmittersBased/EPSONTests/ImageCommandsTests.cs
@@ -1,0 +1,23 @@
+﻿using ESCPOS_NET.Emitters;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using Xunit;
+
+namespace ESCPOS_NET.UnitTest.EmittersBased.EPSONTests
+{
+    public class ImageCommandsTests
+    {
+        [Fact]
+        public void RasterisesText_Success()
+        {
+            var epson = new EPSON();
+            FontCollection collection = new FontCollection();
+            FontFamily family = collection.Install("c://windows/fonts/arial.ttf");
+
+            byte[] rawImage = epson.PrintRasterizedText("Hello world!", family, 24);
+            var renderedImage = Image.Load(rawImage);
+
+            // compare to a fixture?
+        }
+    }
+}

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -27,7 +27,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
-		 <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13" />
+		 <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
 		<PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
 		<PackageReference Include="System.IO.Ports" Version="6.0.0" />
 		<PackageReference Include="System.Text.Json" Version="6.0.4" />

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -27,6 +27,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
+		 <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13" />
 		<PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
 		<PackageReference Include="System.IO.Ports" Version="6.0.0" />
 		<PackageReference Include="System.Text.Json" Version="6.0.4" />

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
@@ -139,7 +139,7 @@ namespace ESCPOS_NET.Emitters
             var bytes = memoryStream.ToArray();
             memoryStream.Dispose();
 
-            return bytes;
+            return PrintImage(bytes, true);
         }
     }
 }

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
@@ -128,8 +128,8 @@ namespace ESCPOS_NET.Emitters
         {
             var font = fontFamily.CreateFont(size, fontStyle);
 
-            var options = new RendererOptions(font);
-            var rect = TextMeasurer.Measure(text, options);
+            TextOptions textOptions = new TextOptions(font);
+            var rect = TextMeasurer.Measure(text, textOptions);
 
             Image image = new Image<Rgba32>((int)rect.Width, (int)rect.Height);
             image.Mutate(x => x.DrawText(text, font, SixLabors.ImageSharp.Color.Black, new PointF(0, 0)));

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
@@ -1,7 +1,11 @@
+using System.IO;
 using ESCPOS_NET.Emitters.BaseCommandValues;
 using ESCPOS_NET.Utilities;
+using SixLabors.Fonts;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Drawing.Processing;
 
 namespace ESCPOS_NET.Emitters
 {
@@ -118,6 +122,24 @@ namespace ESCPOS_NET.Emitters
             {
                 return ByteSplicer.Combine(SetImageDensity(isHiDPI), BufferImage(image, maxWidth, isLegacy, color), WriteImageFromBuffer());
             }
+        }
+
+        public virtual byte[] PrintRasterizedText(string text, FontFamily fontFamily, float size, FontStyle fontStyle = FontStyle.Regular)
+        {
+            var font = fontFamily.CreateFont(size, fontStyle);
+
+            var options = new RendererOptions(font);
+            var rect = TextMeasurer.Measure(text, options);
+
+            Image image = new Image<Rgba32>((int)rect.Width, (int)rect.Height);
+            image.Mutate(x => x.DrawText(text, font, SixLabors.ImageSharp.Color.Black, new PointF(0, 0)));
+
+            var memoryStream = new MemoryStream();
+            image.SaveAsPng(memoryStream);
+            var bytes = memoryStream.ToArray();
+            memoryStream.Dispose();
+
+            return bytes;
         }
     }
 }

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -1,3 +1,5 @@
+using SixLabors.Fonts;
+
 namespace ESCPOS_NET.Emitters
 {
     public interface ICommandEmitter
@@ -66,6 +68,8 @@ namespace ESCPOS_NET.Emitters
         byte[] WriteImageFromBuffer();
 
         byte[] PrintImage(byte[] image, bool isHiDPI, bool isLegacy = false, int maxWidth = -1, int color = 1);
+
+        byte[] PrintRasterizedText(string text, FontFamily fontFamily, float size, FontStyle fontStyle = FontStyle.Regular);
 
         /* Status Commands */
         byte[] EnableAutomaticStatusBack();


### PR DESCRIPTION
This allows us to print a line with a custom font, sizes and weights
which resolves problems with printing text of unsupported sizes (#132)
and unsupported character sets/code pages (#116)

We achieve this by rendering an image with text, sized to fit the text
itself and returning `byte[]` to be compatible with other commands.

Fixes #132, #116

---

I'm opening this as a draft, as I'm a bit stuck on testing and some feedback on the API itself would be great. I'm using this in production currently and it's working quite well.

On the project which this is extracted from, I'm comparing the rendered text to a fixture using [a library I cobbled together from some example code](https://github.com/nickcharlton/image-comparer). It uses `System.Drawing.Common`, rather than `ImageSharp` so one option would be for me to refactor that then use it here, but I'm open to any thoughts on that.

Another problem with testing is needing a `ttf` font. A good choice here might be to bundle an open source font for this purpose, but I'm open to ideas.

Finally, it's in the command emitters for images, which felt the most appropriate for what it's doing but it could easily go somewhere else.