### PR TITLE
Bumps ImageSharp to version 2.0.0

### DIFF
--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -24,7 +24,7 @@ Allows creating receipts with all common functionality supported.</Description>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
     <PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
     <PackageReference Include="System.IO.Ports" Version="4.6.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
@@ -1,6 +1,7 @@
 using ESCPOS_NET.Emitters.BaseCommandValues;
 using ESCPOS_NET.Utilities;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace ESCPOS_NET.Emitters
 {
@@ -59,7 +60,7 @@ namespace ESCPOS_NET.Emitters
             int width;
             int height;
             byte[] imageData;
-            using (var img = Image.Load(image))
+            using (var img = Image.Load<Rgba32>(image))
             {
                 imageData = img.ToSingleBitPixelByteArray(maxWidth: maxWidth == -1 ? (int?)null : maxWidth);
                 height = img.Height;

--- a/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
+++ b/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp
 
             image.ProcessPixelRows(accessor =>
             {
-                for (int y = 0; y < image.Height; y++)
+                for (int y = 0; y < accessor.Height; y++)
                 {
                     var row = accessor.GetRowSpan(y);
                     var rowStartPosition = y * bytesPerRow;

--- a/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
+++ b/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
@@ -37,21 +37,25 @@ namespace SixLabors.ImageSharp
             var bytesPerRow = (image.Width + 7 & -8) / 8;
 
             var result = new byte[bytesPerRow * image.Height];
-            for (int y = 0; y < image.Height; y++)
+
+            image.ProcessPixelRows(accessor =>
             {
-                var row = image.GetPixelRowSpan(y);
-                var rowStartPosition = y * bytesPerRow;
-
-                for (int x = 0; x < row.Length; x++)
+                for (int y = 0; y < image.Height; y++)
                 {
-                    if (!row[x].IsBlack())
-                    {
-                        continue;
-                    }
+                    var row = accessor.GetRowSpan(y);
+                    var rowStartPosition = y * bytesPerRow;
 
-                    result[rowStartPosition + (x / 8)] |= (byte)(0x01 << (7 - (x % 8)));
+                    for (int x = 0; x < row.Length; x++)
+                    {
+                        if (!row[x].IsBlack())
+                        {
+                            continue;
+                        }
+
+                        result[rowStartPosition + (x / 8)] |= (byte)(0x01 << (7 - (x % 8)));
+                    }
                 }
-            }
+            });
 
             return result;
         }


### PR DESCRIPTION
This will bump ImageSharp version to 2.0.0, potentially solving some issues with AOT present in version 1.0.0 (like #164).