### PR TITLE
Bumps ImageSharp to version 2.1.0

### DIFF
--- a/ESCPOS_NET.ConsoleTest/ESCPOS_NET.ConsoleTest.csproj
+++ b/ESCPOS_NET.ConsoleTest/ESCPOS_NET.ConsoleTest.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 

--- a/ESCPOS_NET.ConsoleTest/ESCPOS_NET.ConsoleTest.csproj
+++ b/ESCPOS_NET.ConsoleTest/ESCPOS_NET.ConsoleTest.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ESCPOS_NET.UnitTest/ESCPOS_NET.UnitTest.csproj
+++ b/ESCPOS_NET.UnitTest/ESCPOS_NET.UnitTest.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/ESCPOS_NET.UnitTest/ESCPOS_NET.UnitTest.csproj
+++ b/ESCPOS_NET.UnitTest/ESCPOS_NET.UnitTest.csproj
@@ -1,19 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ESCPOS_NET\ESCPOS_NET.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ESCPOS_NET\ESCPOS_NET.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/ESCPOS_NET.sln
+++ b/ESCPOS_NET.sln
@@ -9,7 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ESCPOS_NET.ConsoleTest", "E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ESCPOS_NET.UnitTest", "ESCPOS_NET.UnitTest\ESCPOS_NET.UnitTest.csproj", "{8A848879-9776-4EBC-8484-41B8EE65FD8D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ESCPOS_NET.TCPPrintServerTest", "ESCPOS_NET.TCPPrintServerTest\ESCPOS_NET.TCPPrintServerTest.csproj", "{A79EB8C9-618F-40AD-ADF3-8794F07E240D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ESCPOS_NET.TCPPrintServerTest", "ESCPOS_NET.TCPPrintServerTest\ESCPOS_NET.TCPPrintServerTest.csproj", "{A79EB8C9-618F-40AD-ADF3-8794F07E240D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -22,12 +22,12 @@ Allows creating receipts with all common functionality supported.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
     <PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
-    <PackageReference Include="System.IO.Ports" Version="4.6.0" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.IO.Ports" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.4" />
   </ItemGroup>
 
 </Project>

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -24,7 +24,7 @@ Allows creating receipts with all common functionality supported.</Description>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
     <PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
     <PackageReference Include="System.IO.Ports" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.4" />

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -1,33 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Company>animalistic.io</Company>
-    <Product>ESCPOS_NET</Product>
-    <Authors>Luke Paireepinart</Authors>
-    <Description>.NET Standard 2.0 Implementation of ESC/POS command generation and integration with thermal printers.
-Allows creating receipts with all common functionality supported.</Description>
-    <Copyright>Copyright 2021 CandL Development, LLC.</Copyright>
-    <PackageLicenseUrl></PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/lukevp/ESC-POS-.NET</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>epson thermal receipt printing printer usb wifi bluetooth serial esc pos escpos escp esc/pos esc/pos.net esc_pos esc_pos_net esc_pos_usb esc_pos_usb_net</PackageTags>
-    <Version>2.0.0</Version>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/lukevp/ESC-POS-.NET</PackageProjectUrl>
-    <PackageReleaseNotes>- Completely rebuilt the network printer code</PackageReleaseNotes>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Company>animalistic.io</Company>
+		<Product>ESCPOS_NET</Product>
+		<Authors>Luke Paireepinart</Authors>
+		<Description>
+			.NET Standard 2.0 Implementation of ESC/POS command generation and integration with thermal printers.
+			Allows creating receipts with all common functionality supported.
+		</Description>
+		<Copyright>Copyright 2021 CandL Development, LLC.</Copyright>
+		<PackageLicenseUrl></PackageLicenseUrl>
+		<RepositoryUrl>https://github.com/lukevp/ESC-POS-.NET</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>epson thermal receipt printing printer usb wifi bluetooth serial esc pos escpos escp esc/pos esc/pos.net esc_pos esc_pos_net esc_pos_usb esc_pos_usb_net</PackageTags>
+		<Version>2.1.0</Version>
+		<AssemblyVersion>2.1.0.0</AssemblyVersion>
+		<FileVersion>2.1.0.0</FileVersion>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/lukevp/ESC-POS-.NET</PackageProjectUrl>
+		<PackageReleaseNotes>- Completely rebuilt the network printer code</PackageReleaseNotes>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
-    <PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
-    <PackageReference Include="System.IO.Ports" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.4" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
+		<PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
+		<PackageReference Include="System.IO.Ports" Version="6.0.0" />
+		<PackageReference Include="System.Text.Json" Version="6.0.4" />
+	</ItemGroup>
 
 </Project>

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -24,7 +24,7 @@ Allows creating receipts with all common functionality supported.</Description>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
     <PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
     <PackageReference Include="System.IO.Ports" Version="4.6.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -10,7 +10,7 @@
 			.NET Standard 2.0 Implementation of ESC/POS command generation and integration with thermal printers.
 			Allows creating receipts with all common functionality supported.
 		</Description>
-		<Copyright>Copyright 2021 CandL Development, LLC.</Copyright>
+		<Copyright>Copyright 2022 CandL Development, LLC.</Copyright>
 		<PackageLicenseUrl></PackageLicenseUrl>
 		<RepositoryUrl>https://github.com/lukevp/ESC-POS-.NET</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/ImageCommands.cs
@@ -1,6 +1,7 @@
 using ESCPOS_NET.Emitters.BaseCommandValues;
 using ESCPOS_NET.Utilities;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace ESCPOS_NET.Emitters
 {
@@ -59,7 +60,7 @@ namespace ESCPOS_NET.Emitters
             int width;
             int height;
             byte[] imageData;
-            using (var img = Image.Load(image))
+            using (var img = Image.Load<Rgba32>(image))
             {
                 imageData = img.ToSingleBitPixelByteArray(maxWidth: maxWidth == -1 ? (int?)null : maxWidth);
                 height = img.Height;

--- a/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
+++ b/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp
 
             image.ProcessPixelRows(accessor =>
             {
-                for (int y = 0; y < image.Height; y++)
+                for (int y = 0; y < accessor.Height; y++)
                 {
                     var row = accessor.GetRowSpan(y);
                     var rowStartPosition = y * bytesPerRow;

--- a/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
+++ b/ESCPOS_NET/Extensions/ImageSharpExtensions.cs
@@ -37,21 +37,25 @@ namespace SixLabors.ImageSharp
             var bytesPerRow = (image.Width + 7 & -8) / 8;
 
             var result = new byte[bytesPerRow * image.Height];
-            for (int y = 0; y < image.Height; y++)
+
+            image.ProcessPixelRows(accessor =>
             {
-                var row = image.GetPixelRowSpan(y);
-                var rowStartPosition = y * bytesPerRow;
-
-                for (int x = 0; x < row.Length; x++)
+                for (int y = 0; y < image.Height; y++)
                 {
-                    if (!row[x].IsBlack())
-                    {
-                        continue;
-                    }
+                    var row = accessor.GetRowSpan(y);
+                    var rowStartPosition = y * bytesPerRow;
 
-                    result[rowStartPosition + (x / 8)] |= (byte)(0x01 << (7 - (x % 8)));
+                    for (int x = 0; x < row.Length; x++)
+                    {
+                        if (!row[x].IsBlack())
+                        {
+                            continue;
+                        }
+
+                        result[rowStartPosition + (x / 8)] |= (byte)(0x01 << (7 - (x % 8)));
+                    }
                 }
-            }
+            });
 
             return result;
         }


### PR DESCRIPTION
This is a successor to #166 
The AOT issue that I had in my app gets fixed by ImageSharp 2.0, but a few steps later, I got another different AOT exception which gets resolved by using ImageSharp 2.1 only
I've also updated test project to .net 6 to make contributions even easier