### PR TITLE
Add Samba printing to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ var printer = new SerialPrinter(portName: "COM5", baudRate: 115200);
 
 // Linux output to USB / Serial file
 var printer = new FilePrinter(filePath: "/dev/usb/lp0");
+
+// Samba
+var printer = new SambaPrinter(tempFileBasePath: @"C:\Temp", filePath: "\\computer\printer");
 ```
 ## Step 1a (optional): Monitor for Events - out of paper, cover open...
 ```csharp


### PR DESCRIPTION
I'm not sure if we need more than this, just enough to highlight using it.

It also made me think that it might be nice to assume the `tempFileBasePath` and pick something smart according to the platform (but probably still allow overriding). Thoughts?