### PR TITLE
Feature/immediate network printer

### DIFF
--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -32,7 +32,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
 		<PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
 		<PackageReference Include="System.IO.Ports" Version="6.0.0" />
 		<PackageReference Include="System.Text.Json" Version="6.0.4" />

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -23,6 +23,12 @@
 		<PackageReleaseNotes>- Completely rebuilt the network printer code</PackageReleaseNotes>
 	</PropertyGroup>
 
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	  <LangVersion>latestmajor</LangVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+	  <LangVersion>latestmajor</LangVersion>
+	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/StatusCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/StatusCommands.cs
@@ -11,8 +11,10 @@ namespace ESCPOS_NET.Emitters
         public virtual byte[] DisableAutomaticStatusBack() => new byte[] { Cmd.GS, Status.AutomaticStatusBack, 0x00 };
 
         public virtual byte[] DisableAutomaticInkStatusBack() => new byte[] { Cmd.GS, Status.AutomaticInkStatusBack, 0x00 };
-        public virtual byte[] RequestPaperStatus() => new byte[] { Cmd.GS, Status.RequestStatus,  0x31 };
-        public virtual byte[] RequestDrawerStatus() => new byte[] { Cmd.GS, Status.RequestStatus, 0x32 };
-        public virtual byte[] RequestInkStatus() => new byte[] { Cmd.GS, Status.RequestStatus, 0x34 };
+        public virtual byte[] RequestOnlineStatus() => new byte[] { Cmd.DLE, Status.RealtimeStatus, 0x01 };
+        public virtual byte[] RequestPaperStatus() => new byte[] { Cmd.GS, Status.RequestStatus, 0x01 };
+        public virtual byte[] RequestDrawerStatus() => new byte[] { Cmd.GS, Status.RequestStatus, 0x02 };
+        public virtual byte[] RequestInkStatus() => new byte[] { Cmd.GS, Status.RequestStatus, 0x04 };
+
     }
 }

--- a/ESCPOS_NET/Emitters/BaseCommandValues/Cmd.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandValues/Cmd.cs
@@ -4,5 +4,6 @@
     {
         public static readonly byte ESC = 0x1B;
         public static readonly byte GS = 0x1D;
+        public static readonly byte DLE = 0x10;
     }
 }

--- a/ESCPOS_NET/Emitters/BaseCommandValues/Status.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandValues/Status.cs
@@ -5,5 +5,6 @@
         public static readonly byte AutomaticStatusBack = 0x61;
         public static readonly byte AutomaticInkStatusBack = 0x6A;
         public static readonly byte RequestStatus = 0x72;
+        public static readonly byte RealtimeStatus = 0x04;
     }
 }

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -1,3 +1,5 @@
+using ESCPOS_NET.Emitters.BaseCommandValues;
+
 namespace ESCPOS_NET.Emitters
 {
     public interface ICommandEmitter
@@ -71,6 +73,19 @@ namespace ESCPOS_NET.Emitters
         byte[] EnableAutomaticStatusBack();
 
         byte[] EnableAutomaticInkStatusBack();
+
+        byte[] DisableAutomaticStatusBack();
+
+        byte[] DisableAutomaticInkStatusBack();
+
+        byte[] RequestOnlineStatus();
+
+        byte[] RequestPaperStatus();
+
+        byte[] RequestDrawerStatus();
+
+        byte[] RequestInkStatus();
+
 
         /* Barcode Commands */
         byte[] PrintBarcode(BarcodeType type, string barcode, BarcodeCode code = BarcodeCode.CODE_B);

--- a/ESCPOS_NET/Printers/BasePrinter.cs
+++ b/ESCPOS_NET/Printers/BasePrinter.cs
@@ -27,8 +27,6 @@ namespace ESCPOS_NET
         public event EventHandler StatusChanged;
         public event EventHandler Disconnected;
         public event EventHandler Connected;
-        //public event EventHandler WriteFailed;
-        //public event EventHandler Idle;
 
         protected BinaryWriter Writer { get; set; }
 
@@ -40,7 +38,7 @@ namespace ESCPOS_NET
 
         protected int BytesWrittenSinceLastFlush { get; set; } = 0;
 
-        protected volatile bool IsConnected  = true;
+        protected volatile bool IsConnected = true;
 
         public string PrinterName { get; protected set; }
 
@@ -148,9 +146,9 @@ namespace ESCPOS_NET
                         DataAvailable();
                     }
                 }
-             
+
                 catch
-                {                    
+                {
                     // Swallow the exception
                     //Logging.Logger?.LogDebug("[{Function}]:[{PrinterName}] Swallowing generic read exception... sometimes happens with serial port printers.", $"{this}.{MethodBase.GetCurrentMethod().Name}", PrinterName);
                 }

--- a/ESCPOS_NET/Printers/IImmediatePrinter.cs
+++ b/ESCPOS_NET/Printers/IImmediatePrinter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using ESCPOS_NET.Emitters;
+using ESCPOS_NET.Printers;
+
+namespace ESCPOS_NET
+{
+    // An ImmediatePrinter is a printer that connects to a printer,
+    // writes/reads data, and then immediately disconnects.
+    // It doesn't queue writes or reads, or keep a connection open to the printer persistently.
+    // Therefore, it should expose async methods because the processing may take some time.
+    public interface IImmediatePrinter
+    {
+        Task<bool> GetOnlineStatus(ICommandEmitter emitter);
+        Task WriteAsync(params byte[][] arrays);
+        Task WriteAsync(byte[] bytes);
+    }
+}

--- a/ESCPOS_NET/Printers/IPrinter.cs
+++ b/ESCPOS_NET/Printers/IPrinter.cs
@@ -7,11 +7,5 @@ namespace ESCPOS_NET
         PrinterStatusEventArgs GetStatus();
         void Write(params byte[][] arrays);
         void Write(byte[] bytes);
-        event EventHandler StatusChanged;
-        event EventHandler Disconnected;
-        event EventHandler Connected;
-        //event EventHandler WriteFailed;
-        //event EventHandler Idle;
-        //event EventHandler IdleDisconnected; is this useful? to know that it disconnected because of idle? probably better to have this as info in disconnected event object instead.
     }
 }

--- a/ESCPOS_NET/Printers/ImmediateNetworkPrinter.cs
+++ b/ESCPOS_NET/Printers/ImmediateNetworkPrinter.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.Extensions.Logging;
+using SimpleTcp;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Reflection;
+using System.Net.Sockets;
+using System.Threading;
+using ESCPOS_NET.Utils;
+using ESCPOS_NET.Utilities;
+using ESCPOS_NET.Emitters;
+using ESCPOS_NET.Printers;
+
+namespace ESCPOS_NET
+{
+    public class ImmediateNetworkPrinterSettings
+    {
+        // Connection string is of the form printer_name:port or ip:port
+        public string ConnectionString { get; set; }
+        public uint? ReceiveTimeoutMs { get; set; }
+        public uint? SendTimeoutMs { get; set; }
+        public uint? ConnectTimeoutMs { get; set; }
+        public string PrinterName { get; set; }
+    }
+
+    public class ImmediateNetworkPrinter : IImmediatePrinter
+    {
+        private readonly ImmediateNetworkPrinterSettings _settings;
+
+
+        public ImmediateNetworkPrinter(ImmediateNetworkPrinterSettings settings)
+        {
+            _settings = settings;
+            _settings.ReceiveTimeoutMs ??= 3000;
+            _settings.ConnectTimeoutMs ??= 5000;
+            _settings.SendTimeoutMs ??= 3000;
+        }
+
+        private async Task<TcpClient> ConnectAsync()
+        {
+            TcpClient client = new TcpClient();
+
+            // ConnectionString is of the form ip:port, or hostname:port, or hostname.
+            var hostnameOrIp = _settings.ConnectionString.Split(':')[0];
+            var port = _settings.ConnectionString.Contains(":") ? int.Parse(_settings.ConnectionString.Split(':')[1]) : 9100;
+
+            try
+            {
+                await CancelableTaskRunnerWithTimeout.RunTask(client.ConnectAsync(hostnameOrIp, port), (int)(_settings.ConnectTimeoutMs ?? 0), CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                Logging.Logger?.LogError(e, "[{Function}]:[{PrinterName}] Unable to connect to printer.", $"{this}.{MethodBase.GetCurrentMethod().Name}", _settings.PrinterName);
+                client.Close();
+                throw;
+            }
+
+            return client;
+        }
+
+        public async Task<bool> GetOnlineStatus(ICommandEmitter emitter)
+        {
+            return await GetOnlineStatus(emitter, null);
+        }
+
+        public async Task<bool> GetOnlineStatus(ICommandEmitter emitter, TcpClient client)
+        {
+            // Connect to printer, write bytes, and return when complete.
+            var didCreateClient = false;
+            if (client == null)
+            {
+                client = await ConnectAsync();
+                didCreateClient = true;
+            }
+            var stream = client.GetStream();
+
+            await WriteAsync(ByteSplicer.Combine(
+                emitter.Initialize(),
+                emitter.Enable(),
+                emitter.RequestOnlineStatus()), client);
+
+            var response = new byte[1];
+            await CancelableTaskRunnerWithTimeout.RunTask(stream.ReadAsync(response, 0, 1), (int)(_settings.ReceiveTimeoutMs ?? 0), CancellationToken.None);
+
+            if (didCreateClient)
+            {
+                client.Close();
+            }
+            return (response[0] & 0x08) == 0;
+        }
+
+
+        public async Task WriteAsync(byte[] bytes)
+        {
+            await WriteAsync(bytes, default(TcpClient));
+
+        }
+
+        public async Task WriteAsync(params byte[][] arrays)
+        {
+            await WriteAsync(ByteSplicer.Combine(arrays), default(TcpClient));
+        }
+
+        public async Task WriteAsync(byte[] bytes, TcpClient client)
+        {
+            // We have 2 ways to call this, one with the client supplied and one without.
+            // If the client is sent in, we assume we shouldn't close it, so that it can be reused.
+            // If we create it in this method, it should be closed.
+            var didCreateClient = false;
+            if (client == null)
+            {
+                client = await ConnectAsync();
+                didCreateClient = true;
+            }
+            var stream = client.GetStream();
+
+            await CancelableTaskRunnerWithTimeout.RunTask(stream.WriteAsync(bytes, 0, bytes.Length), (int)(_settings.SendTimeoutMs ?? 0), CancellationToken.None);
+
+            if (didCreateClient)
+            {
+                client.Close();
+            }
+        }
+
+    }
+}

--- a/ESCPOS_NET/Printers/PaperStatus.cs
+++ b/ESCPOS_NET/Printers/PaperStatus.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace ESCPOS_NET.Printers
+{
+    public class PaperStatus
+    {
+        public bool IsPaperLow { get; set; }
+
+        public bool IsPaperOut { get; set; }
+    }
+}

--- a/ESCPOS_NET/Utils/RunTask.cs
+++ b/ESCPOS_NET/Utils/RunTask.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ESCPOS_NET.Utils
+{
+    public static class CancelableTaskRunnerWithTimeout
+    {
+        public static async Task<T> RunTask<T>(Task<T> task, int timeout = 0, CancellationToken cancellationToken = default)
+        {
+            await RunTask((Task)task, timeout, cancellationToken);
+            return await task;
+        }
+
+        public static async Task RunTask(Task task, int timeout = 0, CancellationToken cancellationToken = default)
+        {
+            if (timeout == 0) timeout = -1;
+
+            var timeoutTask = Task.Delay(timeout, cancellationToken);
+            await Task.WhenAny(task, timeoutTask);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (timeoutTask.IsCompleted)
+            {
+                throw new TimeoutException();
+            }
+            await task;
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ This means that Bluetooth, WiFi, Ethernet, USB, and Serial printers are all usab
 
 ## Step 1: Create a Printer object
 ```csharp
-// Ethernet or WiFi
-var printer = new NetworkPrinter(ipAddress: "192.168.1.50", port: 9000, reconnectOnTimeout: true);
+// Ethernet or WiFi (This uses an Immediate Printer, no live paper status events, but is easier to use)
+var hostnameOrIp = "192.168.1.50";
+var port = 9000;
+var printer = new ImmediateNetworkPrinter(new ImmediateNetworkPrinterSettings() { ConnectionString = $"{hostnameOrIp}:{port}", PrinterName = "TestPrinter" });
 
 // USB, Bluetooth, or Serial
 var printer = new SerialPrinter(portName: "COM5", baudRate: 115200);
@@ -41,7 +43,7 @@ var printer = new SerialPrinter(portName: "COM5", baudRate: 115200);
 // Linux output to USB / Serial file
 var printer = new FilePrinter(filePath: "/dev/usb/lp0");
 ```
-## Step 1a (optional): Monitor for Events - out of paper, cover open...
+## Step 1a (optional): Monitor for Events - out of paper, cover open... 
 ```csharp
 // Define a callback method.
 static void StatusChanged(object sender, EventArgs ps)
@@ -67,7 +69,7 @@ printer.StartMonitoring();
 ## Step 2: Write a receipt to the printer
 ```csharp
 var e = new EPSON();
-printer.Write(
+printer.Write( // or, if using and immediate printer, use await printer.WriteAsync
   ByteSplicer.Combine(
     e.CenterAlign(),
     e.PrintImage(File.ReadAllBytes("images/pd-logo-300.png"), true),
@@ -122,9 +124,11 @@ Desktop support (WiFI, Ethernet, Bluetooth, USB, Serial):
   - ARM platforms such as Raspberry Pi
   - x86/64 platform
 * Mac OSX
-  - Tested on high sierra
+  - Tested from High Sierra to Monterrey, both Intel and M1 architectures
 
 Mobile support (WiFi/Ethernet only):
+**ImmediateNetworkPrinter is the recommended integration type for mobile usage, since mobile applications can background your application at any time**
+* Xamarin.Forms
 * iOS
   - Xamarin.iOS
 * Android
@@ -175,6 +179,7 @@ NOTE: The cross platform .NET library we use from Microsoft only supports COM po
 
 # Implemented Commands
 
+Most common commands are implemented natively in the library's included emitter.
 ## Bit Image Commands
 * `ESC ✻` Select bit-image mode
 * `GS ( L` OR `GS 8 L` Set graphics data
@@ -185,7 +190,6 @@ NOTE: The cross platform .NET library we use from Microsoft only supports COM po
 ## Character Commands
 * `ESC !` Select print mode(s)
 * `GS B` Turn white/black reverse print mode on/off - Thanks @juliogamasso!
-
 
 ## Print Commands
 * `LF` Print and line feed


### PR DESCRIPTION
This feature implements an immediate network printer.  This allows users to directly print to network printers and not worry about persistent connections.  

This is an often-requested feature, as most users do not want to maintain a persistent connection due to the complexity, despite the advantages.

There is a status command enabled to allow retrieving status at any time.