### PR TITLE
Added support for printing Aztec codes and setting left margin print position

### DIFF
--- a/ESCPOS_NET.ConsoleTest/Program.cs
+++ b/ESCPOS_NET.ConsoleTest/Program.cs
@@ -130,6 +130,7 @@ namespace ESCPOS_NET.ConsoleTest
                 { Option.LargeByteArrays, "Large Byte Arrays" },
                 { Option.CashDrawerPin2, "Cash Drawer Pin2" },
                 { Option.CashDrawerPin5, "Cash Drawer Pin5" },
+                { Option.PrintPosition, "Print Position" },
                 { Option.Exit, "Exit" }
 
             };
@@ -213,6 +214,9 @@ namespace ESCPOS_NET.ConsoleTest
                     case Option.CashDrawerPin5:
                         printer.Write(Tests.CashDrawerOpenPin5(e));
                         break;
+                    case Option.PrintPosition:
+                        printer.Write(Tests.Position(e));
+                        break;
                     default:
                         Console.WriteLine("Invalid entry.");
                         break;
@@ -242,6 +246,7 @@ namespace ESCPOS_NET.ConsoleTest
             LargeByteArrays,
             CashDrawerPin2,
             CashDrawerPin5,
+            PrintPosition,
             Exit = 99
         }
 

--- a/ESCPOS_NET.ConsoleTest/Test2DCodes.cs
+++ b/ESCPOS_NET.ConsoleTest/Test2DCodes.cs
@@ -1,10 +1,13 @@
 ﻿using ESCPOS_NET.Emitters;
+using System;
+using System.Text;
 
 namespace ESCPOS_NET.ConsoleTest
 {
     public static partial class Tests
     {
         private const string websiteString = "https://github.com/lukevp/ESC-POS-.NET/";
+
         public static byte[][] TwoDimensionCodes(ICommandEmitter e) => new byte[][] {
             e.PrintLine("PDF417:"),
             e.Print2DCode(TwoDimensionCodeType.PDF417, websiteString),
@@ -36,7 +39,15 @@ namespace ESCPOS_NET.ConsoleTest
 
             e.PrintLine("QRCODE MODEL 1 (LARGE):"),
             e.Print2DCode(TwoDimensionCodeType.QRCODE_MODEL1, websiteString, Size2DCode.LARGE),
-            e.PrintLine()
+            e.PrintLine(),
+
+            e.PrintLine("AZTEC CODE (FULL_RANGE):"),
+            e.PrintAztecCode(websiteString, ModeTypeAztecCode.FULL_RANGE ),
+            e.PrintLine(),
+
+            e.PrintLine("AZTEC CODE (COMPACT):"),
+            e.PrintAztecCode(websiteString, ModeTypeAztecCode.COMPACT),
+            e.PrintLine(),
         };
     }
 }

--- a/ESCPOS_NET.ConsoleTest/TestPrintPosition.cs
+++ b/ESCPOS_NET.ConsoleTest/TestPrintPosition.cs
@@ -1,0 +1,20 @@
+﻿using ESCPOS_NET.Emitters;
+
+namespace ESCPOS_NET.ConsoleTest
+{
+    public static partial class Tests
+    {
+        public static byte[][] Position(ICommandEmitter e) => new byte[][] {
+            e.SetLeftMargin(0),
+            e.PrintLine("Left Margin: This is 0 left margin."),
+            e.SetLeftMargin(10),
+            e.PrintLine("Left Margin: This is 10 left margin."),
+            e.SetLeftMargin(20),
+            e.PrintLine("Left Margin: This is 20 left margin."),
+            e.SetLeftMargin(30),
+            e.PrintLine("Left Margin: This is 30 left margin."),
+            e.SetLeftMargin(0),
+            e.PrintLine("Left Margin: This is 0 left margin."),
+        };
+    }
+}

--- a/ESCPOS_NET/DataValidation/AztecDataConstraint.cs
+++ b/ESCPOS_NET/DataValidation/AztecDataConstraint.cs
@@ -1,0 +1,21 @@
+﻿namespace ESCPOS_NET.DataValidation
+{
+    public class AztecDataConstraint
+    {
+        public int MinLayers { get; set; }
+
+        public int MaxLayers { get; set; }
+
+        public int MinModuleSize { get; set; }
+
+        public int MaxModuleSize { get; set; }
+
+        public int MinCorrectionLevel { get; set; }
+
+        public int MaxCorrectionLevel { get; set; }
+
+        public int MinDataSize { get; set; }
+
+        public int MaxDataSize { get; set; }
+    }
+}

--- a/ESCPOS_NET/DataValidation/AztecDataConstraint.cs
+++ b/ESCPOS_NET/DataValidation/AztecDataConstraint.cs
@@ -13,9 +13,5 @@
         public int MinCorrectionLevel { get; set; }
 
         public int MaxCorrectionLevel { get; set; }
-
-        public int MinDataSize { get; set; }
-
-        public int MaxDataSize { get; set; }
     }
 }

--- a/ESCPOS_NET/DataValidation/AztecDataValidator.cs
+++ b/ESCPOS_NET/DataValidation/AztecDataValidator.cs
@@ -1,0 +1,63 @@
+﻿using ESCPOS_NET.Emitters;
+using System;
+using System.Collections.Generic;
+
+namespace ESCPOS_NET.DataValidation
+{
+    public static class AztecDataValidator
+    {
+        private static Dictionary<ModeTypeAztecCode, AztecDataConstraint> _constraints = new Dictionary<ModeTypeAztecCode, AztecDataConstraint>
+        {
+            { ModeTypeAztecCode.FULL_RANGE, new AztecDataConstraint { MinLayers = 4, MaxLayers = 32, MinModuleSize = 2, MaxModuleSize = 16, MinCorrectionLevel = 5, MaxCorrectionLevel = 95 } },
+            { ModeTypeAztecCode.COMPACT, new AztecDataConstraint { MinLayers = 1, MaxLayers = 4, MinModuleSize = 2, MaxModuleSize = 16, MinCorrectionLevel = 5, MaxCorrectionLevel = 95 } }
+        };
+
+        public static void ValidateAztecCode(ModeTypeAztecCode type, byte[] data, int moduleSize, int correctionLevel, int numberOfDataLayers)
+        {
+            if (data is null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            // Validate constraints on aztec code.
+            _constraints.TryGetValue(type, out var constraints);
+            if (constraints is null)
+            {
+                return;
+            }
+
+            // Check data layers. 0 = automatic processing.
+            if (numberOfDataLayers != 0)
+            {
+                if (numberOfDataLayers < constraints.MinLayers)
+                {
+                    throw new ArgumentException($"Number of data layers '{numberOfDataLayers}' is lower than the minimum {constraints.MinLayers} for {type}.");
+                }
+                else if (constraints.MaxLayers < numberOfDataLayers)
+                {
+                    throw new ArgumentException($"Number of data layers '{numberOfDataLayers}' is higher than the maximum {constraints.MaxLayers} for {type}.");
+                }
+            }
+
+            // Check module size
+            if (moduleSize < constraints.MinModuleSize)
+            {
+                throw new ArgumentException($"Module size '{moduleSize}' is lower than the minimum {constraints.MinModuleSize} for {type}.");
+            }
+            else if (constraints.MaxModuleSize < moduleSize)
+            {
+                throw new ArgumentException($"Module size '{moduleSize}' is higher than the minimum {constraints.MaxModuleSize} for {type}.");
+            }
+
+            // Check correction level
+            if (correctionLevel < constraints.MinCorrectionLevel)
+            {
+                throw new ArgumentException($"Correction level '{correctionLevel}' is lower than the minimum {constraints.MinCorrectionLevel} for {type}.");
+            }
+            else if (constraints.MaxCorrectionLevel < correctionLevel)
+            {
+                throw new ArgumentException($"Correction level '{correctionLevel}' is higher than the minimum {constraints.MaxCorrectionLevel} for {type}.");
+            }
+        }
+    }
+}

--- a/ESCPOS_NET/DataValidation/AztecDataValidator.cs
+++ b/ESCPOS_NET/DataValidation/AztecDataValidator.cs
@@ -58,6 +58,16 @@ namespace ESCPOS_NET.DataValidation
             {
                 throw new ArgumentException($"Correction level '{correctionLevel}' is higher than the minimum {constraints.MaxCorrectionLevel} for {type}.");
             }
+
+            // Try encoding Aztec using ZXing.Net to validate data size
+            try
+            {
+                ZXing.Aztec.Internal.Encoder.encode(data, correctionLevel, numberOfDataLayers);
+            }
+            catch (ArgumentException)
+            {
+                throw;
+            }
         }
     }
 }

--- a/ESCPOS_NET/ESCPOS_NET.csproj
+++ b/ESCPOS_NET/ESCPOS_NET.csproj
@@ -36,6 +36,7 @@
 		<PackageReference Include="SuperSimpleTcp" Version="2.4.0" />
 		<PackageReference Include="System.IO.Ports" Version="6.0.0" />
 		<PackageReference Include="System.Text.Json" Version="6.0.4" />
+		<PackageReference Include="ZXing.Net" Version="0.16.9" />
 	</ItemGroup>
 
 </Project>

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/BarcodeCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/BarcodeCommands.cs
@@ -114,20 +114,22 @@ namespace ESCPOS_NET.Emitters
         public virtual byte[] SetBarLabelFontB(bool fontB) => new byte[] { Cmd.GS, Barcodes.SetBarLabelFont, (byte)(fontB ? 1 : 0) };
 
         /// <inheritdoc />
-        public virtual byte[] PrintAztecCode(string data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int size = 3, int correctionLevel = 23, int numberOfDataLayers = 0)
+        public virtual byte[] PrintAztecCode(string data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int moduleSize = 3, int correctionLevel = 23, int numberOfDataLayers = 0)
         {
             var bytes = data.ToCharArray().Select(x => (byte)x).ToArray();
-            return PrintAztecCode(bytes, modeType, size, correctionLevel, numberOfDataLayers);
+            return PrintAztecCode(bytes, modeType, moduleSize, correctionLevel, numberOfDataLayers);
         }
 
         /// <inheritdoc />
-        public virtual byte[] PrintAztecCode(byte[] data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int size = 3, int correctionLevel = 23, int numberOfDataLayers = 0)
+        public virtual byte[] PrintAztecCode(byte[] data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int moduleSize = 3, int correctionLevel = 23, int numberOfDataLayers = 0)
         {
+            AztecDataValidator.ValidateAztecCode(modeType, data, moduleSize, correctionLevel, numberOfDataLayers);
+
             List<byte> command = new List<byte>();
             byte[] initial = { Cmd.GS, Barcodes.Set2DCode, Barcodes.PrintBarcode };
 
             command.AddRange(initial, Barcodes.SetAztecCodeModeTypeAndNumberOfDataLayers, (byte)modeType, (byte)numberOfDataLayers);
-            command.AddRange(initial, Barcodes.SetAztecCodeSizeOfModule, (byte)size);
+            command.AddRange(initial, Barcodes.SetAztecCodeSizeOfModule, (byte)moduleSize);
             command.AddRange(initial, Barcodes.SetAztecCodeErrorCorrectionLevel, (byte)correctionLevel);
 
             int num = data.Length + 3;

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintPositionCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintPositionCommands.cs
@@ -1,9 +1,22 @@
 ﻿using ESCPOS_NET.Emitters.BaseCommandValues;
+using System;
 
 namespace ESCPOS_NET.Emitters
 {
     public abstract partial class BaseCommandEmitter : ICommandEmitter
     {
-        public virtual byte[] SetLeftMargin(int leftMargin) => new byte[] { Cmd.GS, PrintPosition.LeftMargin, (byte)leftMargin, 0x0 };
+        public virtual byte[] SetLeftMargin(int leftMargin)
+        {
+            if (leftMargin < 0)
+            {
+                throw new ArgumentException($"Left margin '{leftMargin}' is lower than the minimum 0.");
+            }
+            else if (65535 < leftMargin)
+            {
+                throw new ArgumentException($"Left margin '{leftMargin}' is higher than the maximum 65535.");
+            }
+
+            return new byte[] { Cmd.GS, PrintPosition.LeftMargin, (byte)leftMargin, 0x0 };
+        }
     }
 }

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintPositionCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintPositionCommands.cs
@@ -1,0 +1,9 @@
+﻿using ESCPOS_NET.Emitters.BaseCommandValues;
+
+namespace ESCPOS_NET.Emitters
+{
+    public abstract partial class BaseCommandEmitter : ICommandEmitter
+    {
+        public virtual byte[] SetLeftMargin(int leftMargin) => new byte[] { Cmd.GS, PrintPosition.LeftMargin, (byte)leftMargin, 0x0 };
+    }
+}

--- a/ESCPOS_NET/Emitters/BaseCommandValues/Barcodes.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandValues/Barcodes.cs
@@ -22,5 +22,11 @@
         public static readonly byte[] SetQRCodeCorrectionLevel = { 0x03, 0x00, 0x31, 0x45 };
         public static readonly byte[] StoreQRCodeData = { 0x31, 0x50, 0x30 };
         public static readonly byte[] PrintQRCode = { 0x03, 0x00, 0x31, 0x51, 0x30 };
+
+        public static readonly byte[] SetAztecCodeModeTypeAndNumberOfDataLayers = { 0x04, 0x00, 0x35, 0x42 };
+        public static readonly byte[] SetAztecCodeSizeOfModule = { 0x03, 0x00, 0x35, 0x43 };
+        public static readonly byte[] SetAztecCodeErrorCorrectionLevel = { 0x03, 0x00, 0x35, 0x45 };
+        public static readonly byte[] StoreAztecCodeData = { 0x35, 0x50, 0x30 };
+        public static readonly byte[] PrintAztecCode = { 0x03, 0x00, 0x35, 0x51, 0x30 };
     }
 }

--- a/ESCPOS_NET/Emitters/BaseCommandValues/PrintPosition.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandValues/PrintPosition.cs
@@ -1,0 +1,7 @@
+﻿namespace ESCPOS_NET.Emitters.BaseCommandValues
+{
+    public static class PrintPosition
+    {
+        public static readonly byte LeftMargin = 0x4C;
+    }
+}

--- a/ESCPOS_NET/Emitters/Enums/2DCode.cs
+++ b/ESCPOS_NET/Emitters/Enums/2DCode.cs
@@ -27,4 +27,11 @@
         PERCENT_25 = 50,
         PERCENT_30 = 51,
     }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1025:Code should not contain multiple whitespace in a row", Justification = "Enums are easier to read if they have whitespace alignment.")]
+    public enum ModeTypeAztecCode
+    {
+        FULL_RANGE = 48,
+        COMPACT    = 49,
+    }
 }

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -110,7 +110,7 @@ namespace ESCPOS_NET.Emitters
         /// <para>The mode type for Aztec Code.</para>
         /// <para>Default is FULL_RANGE.</para>
         /// </param>
-        /// <param name="size">
+        /// <param name="moduleSize">
         /// <para>The size of one module of Aztec Code in dot units, valid range is 2-16.</para>
         /// <para>Default is 3.</para>
         /// </param>
@@ -123,7 +123,7 @@ namespace ESCPOS_NET.Emitters
         /// <para>0 = automatic processing for the number of layers, valid range is 0-32.</para>
         /// <para>Default is 0.</para>
         /// </param>
-        byte[] PrintAztecCode(string data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int size = 3, int correctionLevel = 23, int numberOfDataLayers = 0);
+        byte[] PrintAztecCode(string data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int moduleSize = 3, int correctionLevel = 23, int numberOfDataLayers = 0);
 
         /// <summary>
         /// Print Aztec Code
@@ -135,7 +135,7 @@ namespace ESCPOS_NET.Emitters
         /// <para>The mode type for Aztec Code.</para>
         /// <para>Default is FULL_RANGE.</para>
         /// </param>
-        /// <param name="size">
+        /// <param name="moduleSize">
         /// <para>The size of one module of Aztec Code in dot units, valid range is 2-16.</para>
         /// <para>Default is 3.</para>
         /// </param>
@@ -148,7 +148,7 @@ namespace ESCPOS_NET.Emitters
         /// <para>0 = automatic processing for the number of layers, valid range is 0-32.</para>
         /// <para>Default is 0.</para>
         /// </param>
-        byte[] PrintAztecCode(byte[] data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int size = 3, int correctionLevel = 23, int numberOfDataLayers = 0);
+        byte[] PrintAztecCode(byte[] data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int moduleSize = 3, int correctionLevel = 23, int numberOfDataLayers = 0);
 
         /* Print Position Commands */
         byte[] SetLeftMargin(int leftMargin);

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -1,5 +1,3 @@
-using ESCPOS_NET.Emitters.BaseCommandValues;
-
 namespace ESCPOS_NET.Emitters
 {
     public interface ICommandEmitter
@@ -86,7 +84,6 @@ namespace ESCPOS_NET.Emitters
 
         byte[] RequestInkStatus();
 
-
         /* Barcode Commands */
         byte[] PrintBarcode(BarcodeType type, string barcode, BarcodeCode code = BarcodeCode.CODE_B);
 
@@ -102,6 +99,56 @@ namespace ESCPOS_NET.Emitters
         byte[] SetBarLabelPosition(BarLabelPrintPosition position);
 
         byte[] SetBarLabelFontB(bool fontB);
+
+        /// <summary>
+        /// Print Aztec Code
+        /// </summary>
+        /// <param name="data">
+        /// <para>Data to print as Aztec Code.</para>
+        /// </param>
+        /// <param name="modeType">
+        /// <para>The mode type for Aztec Code.</para>
+        /// <para>Default is FULL_RANGE.</para>
+        /// </param>
+        /// <param name="size">
+        /// <para>The size of one module of Aztec Code in dot units, valid range is 2-16.</para>
+        /// <para>Default is 3.</para>
+        /// </param>
+        /// <param name="correctionLevel">
+        /// <para>The error correction level in percent, valid range is 5-95.</para>
+        /// <para>Default is 23.</para>
+        /// </param>
+        /// <param name="numberOfDataLayers">
+        /// <para>The number of data layers for Aztec Code.</para>
+        /// <para>0 = automatic processing for the number of layers, valid range is 0-32.</para>
+        /// <para>Default is 0.</para>
+        /// </param>
+        byte[] PrintAztecCode(string data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int size = 3, int correctionLevel = 23, int numberOfDataLayers = 0);
+
+        /// <summary>
+        /// Print Aztec Code
+        /// </summary>
+        /// <param name="data">
+        /// <para>Data to print as Aztec Code.</para>
+        /// </param>
+        /// <param name="modeType">
+        /// <para>The mode type for Aztec Code.</para>
+        /// <para>Default is FULL_RANGE.</para>
+        /// </param>
+        /// <param name="size">
+        /// <para>The size of one module of Aztec Code in dot units, valid range is 2-16.</para>
+        /// <para>Default is 3.</para>
+        /// </param>
+        /// <param name="correctionLevel">
+        /// <para>The error correction level in percent, valid range is 5-95.</para>
+        /// <para>Default is 23.</para>
+        /// </param>
+        /// <param name="numberOfDataLayers">
+        /// <para>The number of data layers for Aztec Code.</para>
+        /// <para>0 = automatic processing for the number of layers, valid range is 0-32.</para>
+        /// <para>Default is 0.</para>
+        /// </param>
+        byte[] PrintAztecCode(byte[] data, ModeTypeAztecCode modeType = ModeTypeAztecCode.FULL_RANGE, int size = 3, int correctionLevel = 23, int numberOfDataLayers = 0);
 
         /* Print Position Commands */
         byte[] SetLeftMargin(int leftMargin);

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -102,5 +102,8 @@ namespace ESCPOS_NET.Emitters
         byte[] SetBarLabelPosition(BarLabelPrintPosition position);
 
         byte[] SetBarLabelFontB(bool fontB);
+
+        /* Print Position Commands */
+        byte[] SetLeftMargin(int leftMargin);
     }
 }


### PR DESCRIPTION
This PR adds support for printing Aztec codes and for setting left margin for print position.
Tested on an Epson TM-m30.

Based on Epson documentation.

Aztec Code: Set the number of mode types and data layers
https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=161

Aztec Code: Set the size of the module
https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=162

Aztec Code: Set the error correction level
https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=163

Aztec Code: Store the data in the symbol storage area
https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=164

Aztec Code: Print the symbol data in the symbol storage area
https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=165

Aztec Code: Transmit the size information of the symbol data in the symbol storage area
https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=166

Set left margin
https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=60