### PR TITLE
Adding Encoding property and examples in the README.md

### DIFF
--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintCommands.cs
@@ -12,7 +12,7 @@ namespace ESCPOS_NET.Emitters
         /* Printing Commands */
         public virtual byte[] Print(string data)
         {
-            // Fix OSX or Windows-style newliness
+            // Fix OSX or Windows-style newlines
             data = Regex.Replace(data, @"\r\n|\r", "\n");
 
             if (Encoding is null)

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintCommands.cs
@@ -12,6 +12,7 @@ namespace ESCPOS_NET.Emitters
         /* Printing Commands */
         public virtual byte[] Print(string data)
         {
+            // Fix OSX or Windows-style newliness
             data = Regex.Replace(data, @"\r\n|\r", "\n");
 
             if (Encoding is null)

--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/PrintCommands.cs
@@ -1,19 +1,26 @@
 ﻿using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using ESCPOS_NET.Emitters.BaseCommandValues;
 
 namespace ESCPOS_NET.Emitters
 {
     public abstract partial class BaseCommandEmitter : ICommandEmitter
     {
+        public Encoding Encoding { get; set; }
+
         /* Printing Commands */
         public virtual byte[] Print(string data)
         {
-            // Fix OSX or Windows-style newlines
-            data = data.Replace("\r\n", "\n");
-            data = data.Replace("\r", "\n");
+            data = Regex.Replace(data, @"\r\n|\r", "\n");
 
-            // TODO: Sanitize...
-            return data.ToCharArray().Select(x => (byte)x).ToArray();
+            if (Encoding is null)
+            {
+                // TODO: Sanitize...
+                return data.ToCharArray().Select(x => (byte)x).ToArray();
+            }
+
+            return Encoding.GetBytes(data);
         }
 
         public virtual byte[] PrintLine(string line)

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -1,9 +1,12 @@
 using ESCPOS_NET.Emitters.BaseCommandValues;
+using System.Text;
 
 namespace ESCPOS_NET.Emitters
 {
     public interface ICommandEmitter
     {
+        Encoding Encoding { get; set; }
+
         /* Print Commands */
         byte[] PrintLine(string line = null);
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,21 @@ printer.Write( // or, if using and immediate printer, use await printer.WriteAsy
   )
 );
 ```
+## Step 3: Print special characters 
+Before you proceed, please make sure you understand the CodePages your printer supports, and if necessary use the [CodePage](https://github.com/lukevp/ESC-POS-.NET/blob/7edaa3f0d9f7298ffe33517074fbc3622e4192a9/ESCPOS_NET/Emitters/BaseCommandEmitter/CharacterCommands.cs#L24) command to change it accordingly to the wanted [encoding](https://en.wikipedia.org/wiki/Character_encoding).
 
+The problem folks usually run into is that C# strings are Unicode, so you are able to declare a string with, for example, the value `€` in C#, but unfortunately, that value does not correctly map to an ASCII 8-bit value that is printable using the standard 7-bit + extended codepages. See [here](https://www.compart.com/en/unicode/U+20AC) for more information
+
+So below an example of how to print `€`
+```cs
+    // € is char 0xD5 at PC858_EURO CodePage
+    var EURO = new byte[] { 0xD5 };
+    printer.Write(ByteSplicer.Combine(e.CodePage(CodePage.PC858_EURO), EURO));
+
+    //Optionally you can return to whatever default CodePage you had before. PC437 in this example
+    printer.Write(e.CodePage(CodePage.PC437_USA_STANDARD_EUROPE_DEFAULT));
+```
+Refer to [this code](https://github.com/lukevp/ESC-POS-.NET/blob/7edaa3f0d9f7298ffe33517074fbc3622e4192a9/ESCPOS_NET.ConsoleTest/TestCodePages.cs#L6-L41) to test your current CodePage, and to [this post](https://github.com/lukevp/ESC-POS-.NET/issues/103#issuecomment-778874734) for a full explanation.
 
 # Supported Platforms
 Desktop support (WiFI, Ethernet, Bluetooth, USB, Serial):
@@ -209,6 +223,7 @@ Most common commands are implemented natively in the library's included emitter.
 * `GS h` Set bar code height
 * `GS k` Print bar code
 * `GS w` Set bar code width
+* `GS ( k` Print 2D bar codes (QRCode and PDF417)
 
 ## Status Commands
 * `GS a` Enable/disable Automatic Status Back (ASB)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,47 @@ So below an example of how to print `€`
 ```
 Refer to [this code](https://github.com/lukevp/ESC-POS-.NET/blob/7edaa3f0d9f7298ffe33517074fbc3622e4192a9/ESCPOS_NET.ConsoleTest/TestCodePages.cs#L6-L41) to test your current CodePage, and to [this post](https://github.com/lukevp/ESC-POS-.NET/issues/103#issuecomment-778874734) for a full explanation.
 
+### Printing Chinese characters
+Assuming your printer has its default CodePage to match [GBK Enconding](https://en.wikipedia.org/wiki/GBK_(character_encoding)) you could accomplish printing chinese characters in 2 ways:
+
+#### 1 - Defining the Encoding in the Emitter
+```cs
+var e = new EPSON { Encoding = System.Text.Encoding.GetEncoding("GBK") };
+string chineseCharactersString = "汉字";
+
+printer.Write( 
+  ByteSplicer.Combine(
+    e.CenterAlign(),
+    e.Print("------------------------------------------"),
+    e.PrintLine(),
+    e.Print(chineseCharactersString),
+    e.PrintLine(),
+    e.Print("------------------------------------------"),
+    e.RightAlign(),
+    e.PrintLine()
+  )
+);
+```
+
+#### 2 - Encoding all strings and directly using them in the Write() method
+```cs
+var encoding = System.Text.Encoding.GetEncoding("GBK");
+var e = new EPSON();
+string chineseCharactersString = "汉字";
+printer.Write( 
+  ByteSplicer.Combine(
+    e.CenterAlign(),
+    e.Print("------------------------------------------"),
+    e.PrintLine(),
+    encoding.GetBytes(chineseCharactersString),
+    e.PrintLine(),
+    e.Print("------------------------------------------"),
+    e.RightAlign(),
+    e.PrintLine()
+  )
+);
+```
+
 # Supported Platforms
 Desktop support (WiFI, Ethernet, Bluetooth, USB, Serial):
 * Windows


### PR DESCRIPTION
Based on discussions on #256 and #88 I have updated the README.md to show how to print Chinese Characters. 

I also added a new property in the Emitter class, so folks can set (and change) their Emitter Encoding at will instead of Encoding all strings before sending to the printer with `Write()`. This will also enable usage of `Print()` command from Emitter which contains cross-OS new line treatment (I also revamped it to use Regex instead of 2 Replace Alls). 