### PR TITLE
+: Add new method for set character's size.

### DIFF
--- a/ESCPOS_NET/Emitters/BaseCommandEmitter/CharacterCommands.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandEmitter/CharacterCommands.cs
@@ -5,7 +5,35 @@ namespace ESCPOS_NET.Emitters
     public abstract partial class BaseCommandEmitter : ICommandEmitter
     {
         /* Character Commands */
+        /// <summary>
+        /// Select print mode(s)
+        /// </summary>
+        /// <param name="style"></param>
+        /// <returns></returns>
         public virtual byte[] SetStyles(PrintStyle style) => new byte[] { Cmd.ESC, Chars.StyleMode, (byte)style };
+
+        /// <summary>
+        /// Select character size. Please reference <see cref="https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=34"/>
+        /// Value from 0 to 7, 0 for normal size.
+        /// </summary>
+        /// <param name="widthMagnification">Enlargement in horizontal direction.</param>
+        /// <param name="heightMagnification">Enlargement in vertical direction.</param>
+        /// <returns></returns>
+        public virtual byte[] SetSize(byte widthMagnification, byte heightMagnification)
+        {
+            if (widthMagnification > 7) widthMagnification = 7;
+            if (heightMagnification > 7) heightMagnification = 7;
+
+            return [Cmd.GS, Chars.SizeMode, (byte)(widthMagnification * 0x10 + heightMagnification)];
+        }
+
+        /// <summary>
+        /// Select character size. Please reference <see cref="https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=34"/>
+        /// Set both width and height magnification in same value.
+        /// </summary>
+        /// <param name="magnification">Enlargement in both horizontal and vertical direction.</param>
+        /// <returns></returns>
+        public virtual byte[] SetSize(byte magnification) => SetSize(magnification, magnification);
 
         public virtual byte[] LeftAlign() => new byte[] { Cmd.ESC, Chars.Alignment, (byte)Align.Left };
 

--- a/ESCPOS_NET/Emitters/BaseCommandValues/Chars.cs
+++ b/ESCPOS_NET/Emitters/BaseCommandValues/Chars.cs
@@ -2,7 +2,8 @@
 {
     public static class Chars
     {
-        public static readonly byte StyleMode = 0x21;
+        public static readonly byte StyleMode = 0x21;/**ASCII Char: !*/
+        public static readonly byte SizeMode = StyleMode;
         public static readonly byte Alignment = 0x61;
         public static readonly byte ReversePrintMode = 0x42;
         public static readonly byte RightCharacterSpacing = 0x20;

--- a/ESCPOS_NET/Emitters/ICommandEmitter.cs
+++ b/ESCPOS_NET/Emitters/ICommandEmitter.cs
@@ -38,6 +38,10 @@ namespace ESCPOS_NET.Emitters
         /* Character Commands */
         byte[] SetStyles(PrintStyle style);
 
+        byte[] SetSize(byte widthMagnification, byte heightMagnification);
+
+        byte[] SetSize(byte magnification);
+
         byte[] LeftAlign();
 
         byte[] RightAlign();


### PR DESCRIPTION
Hi Luke,
Thanks for your great project for printing receipt with ESC/POS protocal via C#.
As a developer from China, I mainly print Chinese chars ( Here, I want to thank you again for specially pointing out how to set GBK encoding in the ramp up document). I need to set the chars in different size.
So as the title mentioned, I have add a new method to support set characters' size.

I try to keep the code style as yours, hope these codes can be accessed. ;-)

And I'm going to add another support for .NET MAUI application, print receipt with Android/iOS device via bluetooth. I'll keep update to you if done.

Thanks and BR,
Lionden L.